### PR TITLE
fix(cli): secure resumable upload state directory

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 import re  # Needed by mypy.
 import shutil
+import stat
 import sys
 import tarfile
 import tempfile
@@ -575,9 +576,16 @@ class ResumableUploadContext(object):
     the state of each file upload within the context.
     """
 
+    # Upload state holds the signed upload url and the blob token, so it must not be
+    # readable (or replaceable) by other users of the machine. The state has to survive
+    # across CLI invocations for a resume to work, so it cannot live in a fresh
+    # mkdtemp() per process like DirectoryArchive does; it uses a stable per-user path
+    # created with owner-only permissions instead.
+    UPLOAD_STATE_DIR_MODE = 0o700
+
     def __init__(self, no_resume: bool = False) -> None:
         self.no_resume = no_resume
-        self._temp_dir = os.path.join(tempfile.gettempdir(), ".kaggle/uploads")
+        self._temp_dir = os.path.join(tempfile.gettempdir(), self._upload_state_dir_name())
         self._file_uploads: List["ResumableFileUpload"] = []
 
     def __enter__(self) -> "ResumableUploadContext":
@@ -615,11 +623,49 @@ class ResumableUploadContext(object):
         file_upload.load()
         return file_upload
 
+    @staticmethod
+    def _upload_state_dir_name() -> str:
+        """Name of the upload state directory, scoped to the current user.
+
+        The system temp directory is shared by every user on POSIX, so a single
+        well-known name would let one user pre-create (and therefore control, or
+        simply lock out) another user's state directory.
+        """
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is None:  # Windows: the temp directory is already per-user.
+            return ".kaggle-uploads"
+        return ".kaggle-uploads-%d" % geteuid()
+
     def _create_temp_dir(self) -> None:
-        try:
-            os.makedirs(self._temp_dir)
-        except FileExistsError:
-            pass
+        os.makedirs(self._temp_dir, mode=self.UPLOAD_STATE_DIR_MODE, exist_ok=True)
+        self._verify_temp_dir_is_private()
+
+    def _verify_temp_dir_is_private(self) -> None:
+        """Refuse to use an upload state directory that another user could control.
+
+        ``makedirs`` happily accepts a directory (or a symlink to one) that was
+        pre-created by somebody else, so the directory we ended up with is checked
+        rather than assumed.
+        """
+        info = os.lstat(self._temp_dir)
+        if stat.S_ISLNK(info.st_mode):
+            raise ValueError(
+                "Refusing to use upload state directory %s because it is a symlink. "
+                "Remove it and try again." % self._temp_dir
+            )
+        geteuid = getattr(os, "geteuid", None)
+        if geteuid is None:  # Windows: no meaningful owner/permission bits to check.
+            return
+        if info.st_uid != geteuid():
+            raise ValueError(
+                "Refusing to use upload state directory %s because it is owned by "
+                "another user. Remove it and try again." % self._temp_dir
+            )
+        if info.st_mode & 0o077:
+            raise ValueError(
+                "Refusing to use upload state directory %s because it is accessible to "
+                "other users. Remove it and try again." % self._temp_dir
+            )
 
 
 class ResumableFileUpload(object):

--- a/tests/unit/test_upload_helpers.py
+++ b/tests/unit/test_upload_helpers.py
@@ -869,5 +869,95 @@ class TestResumableFileUpload(unittest.TestCase):
             self.assertTrue(file_upload.can_resume)
 
 
+class TestResumableUploadStateDir(unittest.TestCase):
+    """Tests that the upload state directory cannot be read or planted by another user.
+
+    The state files hold the signed upload url and the blob token, so a directory that
+    somebody else owns (or a symlink they left behind) must not be reused.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        from kagglesdk.blobs.types.blob_api_service import ApiStartBlobUploadRequest
+
+        self.req = ApiStartBlobUploadRequest()
+        self.req.name = "test.bin"
+        self.req.type = ApiBlobType.INBOX
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @unittest.skipIf(not hasattr(os, "geteuid"), "POSIX-only permission semantics")
+    @patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir")
+    def test_state_dir_is_owner_only(self, mock_tempdir):
+        mock_tempdir.return_value = self.temp_dir
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        with ResumableUploadContext(no_resume=False) as context:
+            mode = os.stat(context._temp_dir).st_mode
+            self.assertEqual(mode & 0o777, 0o700)
+
+    @unittest.skipIf(not hasattr(os, "geteuid"), "POSIX-only permission semantics")
+    @patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir")
+    def test_state_dir_is_scoped_to_current_user(self, mock_tempdir):
+        mock_tempdir.return_value = self.temp_dir
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        context = ResumableUploadContext(no_resume=False)
+        self.assertIn(str(os.geteuid()), os.path.basename(context._temp_dir))
+
+    @patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir")
+    def test_symlinked_state_dir_is_rejected(self, mock_tempdir):
+        mock_tempdir.return_value = self.temp_dir
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        planted = os.path.join(self.temp_dir, "planted")
+        os.makedirs(planted)
+        state_dir = ResumableUploadContext(no_resume=False)._temp_dir
+        os.makedirs(os.path.dirname(state_dir), exist_ok=True)
+        os.symlink(planted, state_dir)
+
+        with self.assertRaises(ValueError) as cm:
+            with ResumableUploadContext(no_resume=False):
+                pass
+
+        self.assertIn("symlink", str(cm.exception))
+
+    @unittest.skipIf(not hasattr(os, "geteuid"), "POSIX-only permission semantics")
+    @patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir")
+    def test_group_or_world_accessible_state_dir_is_rejected(self, mock_tempdir):
+        mock_tempdir.return_value = self.temp_dir
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext
+
+        state_dir = ResumableUploadContext(no_resume=False)._temp_dir
+        os.makedirs(state_dir)
+        os.chmod(state_dir, 0o777)
+
+        with self.assertRaises(ValueError) as cm:
+            with ResumableUploadContext(no_resume=False):
+                pass
+
+        self.assertIn("accessible to other users", str(cm.exception))
+
+    @patch("kaggle.api.kaggle_api_extended.tempfile.gettempdir")
+    def test_state_survives_across_contexts(self, mock_tempdir):
+        """A resume still works when a later invocation builds a fresh context."""
+        mock_tempdir.return_value = self.temp_dir
+        from kaggle.api.kaggle_api_extended import ResumableUploadContext, ResumableFileUpload
+
+        with ResumableUploadContext(no_resume=False) as first:
+            started = ResumableFileUpload("path.bin", self.req, first)
+            response = ApiStartBlobUploadResponse()
+            response.token = "valid-token"
+            response.create_url = "http://valid-url"
+            started.upload_initiated(response)
+
+        with ResumableUploadContext(no_resume=False) as second:
+            resumed = ResumableFileUpload("path.bin", self.req, second)
+            resumed.load()
+            self.assertTrue(resumed.can_resume)
+            self.assertEqual(resumed.start_blob_upload_response.token, "valid-token")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Resumable upload state was stored in a shared temporary directory. On Linux, this usually meant `/tmp/.kaggle/uploads`, which could be accessible to other users on the same machine.

The state files contain information needed to resume an upload, including the upload URL and blob token. Since the directory used a fixed path and an existing directory was reused without checking it, another local user could potentially read or modify this state.

This change stores resumable upload state in a private per-user directory and verifies that an existing directory is safe before using it.

## Fix

Updated the resumable upload state directory to be scoped to the current user and created with `0700` permissions.

Existing directories are also checked before use to make sure they are not symlinks, are owned by the current user, and are not accessible to other users.

The directory remains stable across CLI runs so resumable uploads continue to work as before.

After this change:

* Upload state is stored separately for each user.
* The state directory is only accessible by its owner.
* Symlinked or unsafe existing state directories are rejected.
* Resumable uploads still work across separate CLI runs.

## Tests

Added tests for the resumable upload state directory covering permissions, per-user paths, unsafe existing directories, symlinks, and resume behavior across separate contexts.

Ran:

`pytest tests/unit/test_upload_helpers.py -v`

`pytest tests/unit/test_upload_helpers.py tests/unit/test_dataset_create.py tests/unit/test_model_create.py`

`pytest tests/unit`

`black --check <modified files>`

`mypy src/kaggle tests`

All checks pass, including the full unit test suite with 1243 tests passing.
