### PR TITLE
feat(benchmarks): add quota command for Model Proxy spend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Add `kaggle benchmarks quota` to show Model Proxy (AI inference) spend quota, and bump `kagglesdk` to `>= 0.1.37`
 * Add `kaggle competitions submission-download <id>` to download the submitted file for a single submission (requires `kagglesdk >= 0.1.36`)
 * Add `deadline` (Competition Deadline) to the competition settings command and bump `kagglesdk` to `>= 0.1.36`
 * Document that `NvidiaTeslaP100` is unusable for GPU compute with the default Kaggle image (PyTorch cu128 omits Pascal `sm_60` kernels)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,6 +6,7 @@ The top-level command is `kaggle benchmarks` (alias: `kaggle b`), which has the 
 
 *   **`auth`** — Fetch Model Proxy credentials.
 *   **`init`** — Fetch credentials and default environment variables for local development.
+*   **`quota`** — Show your Model Proxy (AI inference) spend quota.
 *   **`leaderboard`** — Get benchmark leaderboard information.
 *   **`tasks`** (alias: `t`) — Manage benchmark tasks (push, run, list, status, download, log, models, delete, publish).
 *   **`topics`** — Browse discussion topics for a benchmark.
@@ -88,6 +89,37 @@ In addition to the three credential variables written by `auth`, `init` also wri
 *   **`kaggle_benchmarks_reference.md`** — A syntax reference document for the `kaggle-benchmarks` task API.
 
 If either file already exists, it is skipped without overwriting.
+
+---
+
+## `kaggle benchmarks quota`
+
+Shows your current Model Proxy (AI inference) spend quota, one row per refill period.
+
+**Usage:**
+
+```bash
+kaggle benchmarks quota [options]
+```
+
+**Options:**
+
+*   `-v, --csv`: Print results in CSV format.
+*   `--format <FORMAT>`: Print results in the selected format (`csv`, `table`, `json`).
+
+**Example:**
+
+```bash
+$ kaggle b quota
+period   used    remaining  total    refillAt
+-------  ------  ---------  -------  -------------------------
+Daily    $1.20   $3.80      $5.00    2026-08-08T00:00:00+00:00
+Monthly  $14.50  $85.50     $100.00  2026-09-01T00:00:00+00:00
+```
+
+**Purpose:**
+
+Amounts are in USD and reflect inference spend through the Model Proxy — this is separate from the top-level `kaggle quota` command, which reports weekly GPU and TPU accelerator *hours*. `remaining` is derived as `total - used` and is clamped at `$0.00`, so an overage shows as zero remaining rather than a negative balance.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["Kaggle", "API"]
 requires-python = ">= 3.11"
 dependencies = [
     "bleach",
-    "kagglesdk >= 0.1.36, < 1.0", # sync with kagglehub
+    "kagglesdk >= 0.1.37, < 1.0", # sync with kagglehub
     "python-slugify",
     "requests",
     "python-dateutil",

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,7 +26,7 @@ jupyter-core==5.9.1
     # via nbformat
 jupytext==1.19.1
     # via kaggle (pyproject.toml)
-kagglesdk==0.1.36
+kagglesdk==0.1.37
     # via kaggle (pyproject.toml)
 markdown-it-py==4.0.0
     # via

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -241,8 +241,16 @@ from kagglesdk.models.types.model_api_service import (
     ApiListModelInstancesRequest,
     ApiListModelInstancesResponse,
 )
-from kagglesdk.models.types.model_enums import ListModelsOrderBy, ModelInstanceType, ModelFramework
-from kagglesdk.models.types.model_proxy_api_service import ApiCreateDefaultModelProxyTokenRequest
+from kagglesdk.models.types.model_enums import (
+    ListModelsOrderBy,
+    ModelInstanceType,
+    ModelFramework,
+    ModelProxyQuotaRefillPeriod,
+)
+from kagglesdk.models.types.model_proxy_api_service import (
+    ApiCreateDefaultModelProxyTokenRequest,
+    ApiGetModelProxyQuotasRequest,
+)
 from kagglesdk.models.types.model_types import Owner
 from kagglesdk.search.types.search_api_service import (
     ApiListType,
@@ -10167,6 +10175,36 @@ class KaggleApi:
 
     # -- Public CLI methods --
 
+    @staticmethod
+    def _translate_model_proxy_error(e):
+        """Re-raise a Model Proxy HTTPError as a ValueError with actionable causes.
+
+        Args:
+            e: The HTTPError raised by a Model Proxy endpoint.
+
+        Raises:
+            ValueError: For 404 and 403 responses, which have known causes.
+            HTTPError: The original error, for any other status.
+        """
+        status = e.response.status_code if e.response is not None else None
+        if status == 404:
+            raise ValueError(
+                "Endpoint not found (404). Possible causes:\n"
+                "  1. Kaggle Benchmarks is currently in beta and isn't enabled on your account.\n"
+                "     Request access from the Kaggle Benchmarks team and try again once enabled.\n"
+                "  2. Your Kaggle CLI may be out of date.\n"
+                "     Upgrade with `pip install --upgrade kaggle` and re-run this command."
+            ) from None
+        if status == 403:
+            raise ValueError(
+                "Authentication failed (403). Possible causes:\n"
+                "  1. Your account is missing phone or identity verification.\n"
+                "     Verify at https://www.kaggle.com/settings.\n"
+                "  2. Your Kaggle API credentials are stale or invalid.\n"
+                "     Regenerate at https://www.kaggle.com/settings/api and replace ~/.kaggle/access_token (or kaggle.json)."
+            ) from None
+        raise e
+
     def _fetch_model_proxy_env(self, source):
         with self.build_kaggle_client() as kaggle:
             # Tag this request so kaggle-analytics can distinguish
@@ -10178,24 +10216,7 @@ class KaggleApi:
             try:
                 response = kaggle.models.model_proxy_api_client.create_default_model_proxy_token(request)
             except HTTPError as e:
-                status = e.response.status_code if e.response is not None else None
-                if status == 404:
-                    raise ValueError(
-                        "Endpoint not found (404). Possible causes:\n"
-                        "  1. Kaggle Benchmarks is currently in beta and isn't enabled on your account.\n"
-                        "     Request access from the Kaggle Benchmarks team and try again once enabled.\n"
-                        "  2. Your Kaggle CLI may be out of date.\n"
-                        "     Upgrade with `pip install --upgrade kaggle` and re-run this command."
-                    ) from None
-                if status == 403:
-                    raise ValueError(
-                        "Authentication failed (403). Possible causes:\n"
-                        "  1. Your account is missing phone or identity verification.\n"
-                        "     Verify at https://www.kaggle.com/settings.\n"
-                        "  2. Your Kaggle API credentials are stale or invalid.\n"
-                        "     Regenerate at https://www.kaggle.com/settings/api and replace ~/.kaggle/access_token (or kaggle.json)."
-                    ) from None
-                raise
+                self._translate_model_proxy_error(e)
         return {
             "MODEL_PROXY_URL": response.base_uri,
             "MODEL_PROXY_API_KEY": response.token,
@@ -10298,6 +10319,60 @@ class KaggleApi:
     def benchmarks_auth_cli(self, no_confirm=False, env_file=".env"):
         env_vars = self._fetch_model_proxy_env(source="auth")
         self._write_benchmarks_env(env_vars, no_confirm, env_file)
+
+    def benchmarks_quota(self):
+        """Fetches the current user's Model Proxy (AI inference) quota balances.
+
+        Returns:
+            An ApiGetModelProxyQuotasResponse with a quota_balances field holding
+            one balance per refill period (daily and monthly).
+        """
+        with self.build_kaggle_client() as kaggle:
+            try:
+                return kaggle.models.model_proxy_api_client.get_model_proxy_quotas(ApiGetModelProxyQuotasRequest())
+            except HTTPError as e:
+                self._translate_model_proxy_error(e)
+
+    def benchmarks_quota_cli(self, csv_display=False, output_format=None):
+        """A client wrapper for benchmarks_quota.
+
+        Args:
+            csv_display: If True, print comma-separated values instead of a table.
+            output_format: The output format to use.
+        """
+        response = self.benchmarks_quota()
+        rows = []
+        for balance in response.quota_balances or []:
+            used = balance.quota_used
+            total = balance.total_quota_allowed
+            rows.append(
+                SimpleNamespace(
+                    period=self._format_refill_period(balance.refill_period),
+                    used=f"${used:.2f}",
+                    remaining=f"${max(0.0, total - used):.2f}",
+                    total=f"${total:.2f}",
+                    refill_at=balance.refill_time.isoformat() if balance.refill_time else "",
+                )
+            )
+        if not rows:
+            print("No quota information available")
+            return
+        fields = ["period", "used", "remaining", "total", "refillAt"]
+        self.print_results(
+            rows,
+            fields,
+            csv_display=csv_display,
+            output_format=output_format,
+        )
+
+    @staticmethod
+    def _format_refill_period(refill_period):
+        """Renders a ModelProxyQuotaRefillPeriod as a display label."""
+        labels = {
+            ModelProxyQuotaRefillPeriod.DAILY: "Daily",
+            ModelProxyQuotaRefillPeriod.MONTHLY: "Monthly",
+        }
+        return labels.get(refill_period, "Unknown")
 
     def benchmarks_init_cli(self, no_confirm=False, env_file=".env", example_file="example_task.py"):
         print("Initializing Kaggle Benchmarks environment")

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1949,6 +1949,7 @@ def parse_benchmarks(subparsers) -> None:
     parse_benchmark_tasks(subparsers_benchmarks)
     parse_benchmarks_auth(subparsers_benchmarks)
     parse_benchmarks_init(subparsers_benchmarks)
+    parse_benchmarks_quota(subparsers_benchmarks)
     parse_benchmarks_leaderboard(subparsers_benchmarks)
 
     shared_topics = _get_shared_topics_parser()
@@ -2036,6 +2037,14 @@ def parse_benchmarks_init(subparsers) -> None:
     )
     parser_init._action_groups.append(parser_init_optional)
     parser_init.set_defaults(func=api.benchmarks_init_cli)
+
+
+def parse_benchmarks_quota(subparsers) -> None:
+    parser_quota = subparsers.add_parser(
+        "quota", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_benchmarks_quota
+    )
+    _add_output_format_args(parser_quota)
+    parser_quota.set_defaults(func=api.benchmarks_quota_cli)
 
 
 def parse_benchmarks_leaderboard(subparsers) -> None:
@@ -2560,7 +2569,7 @@ class Help(object):
     model_instances_choices = ["versions", "v", "get", "files", "list", "init", "create", "delete", "update"]
     model_instance_versions_choices = ["init", "create", "download", "delete", "files", "list"]
     files_choices = ["upload"]
-    benchmarks_choices = ["tasks", "t", "auth", "init", "topics", "leaderboard"]
+    benchmarks_choices = ["tasks", "t", "auth", "init", "quota", "topics", "leaderboard"]
     benchmarks_tasks_choices = [
         "push",
         "run",
@@ -2722,6 +2731,7 @@ class Help(object):
     command_benchmarks_init = (
         "Fetch and persist  Model Proxy credentials and other Kaggle Benchmarks environment variables"
     )
+    command_benchmarks_quota = "Show the current user's Model Proxy (AI inference) spend quota, in USD"
     command_benchmarks_tasks_push = "Create or update a task from a Python source file"
     command_benchmarks_tasks_run = "Run a task against model(s)"
 

--- a/tests/unit/test_benchmarks_quota.py
+++ b/tests/unit/test_benchmarks_quota.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+import io
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests import HTTPError
+
+sys.path.insert(0, "../..")
+
+from kagglesdk.models.types.model_enums import ModelProxyQuotaRefillPeriod
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def _mock_balance(used, total, refill_period, refill_time=None):
+    balance = MagicMock()
+    balance.quota_used = used
+    balance.total_quota_allowed = total
+    balance.refill_period = refill_period
+    balance.refill_time = refill_time
+    return balance
+
+
+def _build_response(balances):
+    response = MagicMock()
+    response.quota_balances = balances
+    return response
+
+
+def _http_error(status_code):
+    response = MagicMock()
+    response.status_code = status_code
+    return HTTPError(response=response)
+
+
+class TestBenchmarksQuota(unittest.TestCase):
+    """Tests for the benchmarks_quota and benchmarks_quota_cli methods."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    def _patch_client(self, mock_client, quotas_client):
+        mock_kaggle = MagicMock()
+        mock_kaggle.models.model_proxy_api_client = quotas_client
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_benchmarks_quota_returns_response(self, mock_client):
+        expected = _build_response([_mock_balance(1.2, 5.0, ModelProxyQuotaRefillPeriod.DAILY)])
+        quotas_client = MagicMock()
+        quotas_client.get_model_proxy_quotas.return_value = expected
+        self._patch_client(mock_client, quotas_client)
+
+        result = self.api.benchmarks_quota()
+
+        self.assertIs(result, expected)
+        quotas_client.get_model_proxy_quotas.assert_called_once()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_benchmarks_quota_404_raises_friendly_error(self, mock_client):
+        quotas_client = MagicMock()
+        quotas_client.get_model_proxy_quotas.side_effect = _http_error(404)
+        self._patch_client(mock_client, quotas_client)
+
+        with pytest.raises(ValueError, match="Endpoint not found"):
+            self.api.benchmarks_quota()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_benchmarks_quota_403_raises_friendly_error(self, mock_client):
+        quotas_client = MagicMock()
+        quotas_client.get_model_proxy_quotas.side_effect = _http_error(403)
+        self._patch_client(mock_client, quotas_client)
+
+        with pytest.raises(ValueError, match="Authentication failed"):
+            self.api.benchmarks_quota()
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_benchmarks_quota_other_error_propagates(self, mock_client):
+        quotas_client = MagicMock()
+        quotas_client.get_model_proxy_quotas.side_effect = _http_error(500)
+        self._patch_client(mock_client, quotas_client)
+
+        with pytest.raises(HTTPError):
+            self.api.benchmarks_quota()
+
+    def _run_cli(self, **kwargs):
+        captured = io.StringIO()
+        sys.stdout = captured
+        try:
+            self.api.benchmarks_quota_cli(**kwargs)
+        finally:
+            sys.stdout = sys.__stdout__
+        return captured.getvalue()
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_table(self, mock_view):
+        mock_view.return_value = _build_response(
+            [
+                _mock_balance(
+                    1.2,
+                    5.0,
+                    ModelProxyQuotaRefillPeriod.DAILY,
+                    refill_time=datetime(2026, 8, 8, tzinfo=timezone.utc),
+                ),
+                _mock_balance(
+                    14.5,
+                    100.0,
+                    ModelProxyQuotaRefillPeriod.MONTHLY,
+                    refill_time=datetime(2026, 9, 1, tzinfo=timezone.utc),
+                ),
+            ]
+        )
+
+        output = self._run_cli()
+
+        self.assertIn("period", output)
+        self.assertIn("refillAt", output)
+        self.assertIn("Daily", output)
+        self.assertIn("Monthly", output)
+        # Remaining is derived: total - used.
+        self.assertIn("$3.80", output)
+        self.assertIn("$85.50", output)
+        self.assertIn("2026-08-08T00:00:00+00:00", output)
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_clamps_negative_remaining(self, mock_view):
+        """Overage must not render as a negative remaining balance."""
+        mock_view.return_value = _build_response([_mock_balance(7.5, 5.0, ModelProxyQuotaRefillPeriod.DAILY)])
+
+        output = self._run_cli()
+
+        self.assertIn("$0.00", output)
+        self.assertNotIn("-$", output)
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_missing_refill_time(self, mock_view):
+        mock_view.return_value = _build_response([_mock_balance(1.0, 5.0, ModelProxyQuotaRefillPeriod.DAILY)])
+
+        output = self._run_cli()
+
+        self.assertIn("Daily", output)
+        self.assertIn("$4.00", output)
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_unspecified_period(self, mock_view):
+        mock_view.return_value = _build_response(
+            [_mock_balance(1.0, 5.0, ModelProxyQuotaRefillPeriod.REFILL_PERIOD_UNSPECIFIED)]
+        )
+
+        output = self._run_cli()
+
+        self.assertIn("Unknown", output)
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_no_balances(self, mock_view):
+        mock_view.return_value = _build_response([])
+
+        output = self._run_cli()
+
+        self.assertIn("No quota information available", output)
+
+    @patch.object(KaggleApi, "benchmarks_quota")
+    def test_benchmarks_quota_cli_csv(self, mock_view):
+        mock_view.return_value = _build_response([_mock_balance(1.2, 5.0, ModelProxyQuotaRefillPeriod.DAILY)])
+
+        output = self._run_cli(csv_display=True)
+
+        self.assertIn("period,used,remaining,total,refillAt", output)
+        self.assertIn("Daily,$1.20,$3.80,$5.00", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cli_benchmarks.py
+++ b/tests/unit/test_cli_benchmarks.py
@@ -36,6 +36,25 @@ def test_benchmarks_init_parser_with_flags_succeeds(parser):
     assert kwargs["example_file"] == "my_example.py"
 
 
+def test_benchmarks_quota_parser_default_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "quota"])
+    assert func.__name__ == "benchmarks_quota_cli"
+    assert kwargs.get("csv_display") is False
+    assert kwargs.get("output_format") is None
+
+
+def test_benchmarks_quota_parser_with_format_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "quota", "--format", "json"])
+    assert func.__name__ == "benchmarks_quota_cli"
+    assert kwargs["output_format"] == "json"
+
+
+def test_benchmarks_quota_parser_csv_succeeds(parser):
+    func, kwargs = parser.dispatch(["benchmarks", "quota", "-v"])
+    assert func.__name__ == "benchmarks_quota_cli"
+    assert kwargs["csv_display"] is True
+
+
 def test_benchmarks_leaderboard_parser_missing_benchmark_fails(parser):
     with pytest.raises(SystemExit):
         parser.dispatch(["benchmarks", "leaderboard"])


### PR DESCRIPTION
Bump kagglesdk to 0.1.37 and expose the new GetModelProxyQuotas endpoint as `kaggle benchmarks quota`.

The command reports AI inference spend in USD, one row per refill period (daily and monthly). This is distinct from the top-level `kaggle quota`, which reports weekly GPU/TPU accelerator hours, so it lives under `benchmarks` alongside `auth` and `init` — the other commands that hit the Model Proxy.

Remaining is derived as total - used and clamped at $0.00 so an overage reads as zero rather than a negative balance, matching the existing quota_view_cli behavior.

Also extracts the 404/403 friendly-error mapping out of _fetch_model_proxy_env into a shared _translate_model_proxy_error helper, since the quota endpoint has the same beta-access and phone-verification failure modes.