### PR TITLE
Add kernel session cancellation command

### DIFF
--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -299,6 +299,30 @@ kaggle kernels status kerneler/sqlite-global-default
 
 This command tells you whether the latest run of your kernel is still running, completed successfully, or failed.
 
+## `kaggle kernels cancel`
+
+Requests cancellation of one kernel session without deleting the kernel or its outputs.
+
+**Usage:**
+
+```bash
+kaggle kernels cancel --session-id <SESSION_ID>
+```
+
+**Options:**
+
+*   `--session-id <SESSION_ID>`: Numeric kernel session ID to cancel.
+
+**Example:**
+
+```bash
+kaggle kernels cancel --session-id 123456789
+```
+
+**Purpose:**
+
+Use this command to stop an accidentally submitted or stuck session while preserving the kernel, its inputs, and historical outputs.
+
 ## `kaggle kernels delete`
 
 Deletes a kernel from Kaggle.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -212,6 +212,7 @@ from kagglesdk.kernels.types.kernels_api_service import (
     ApiSaveKernelResponse,
     ApiKernelMetadata,
     ApiDeleteKernelRequest,
+    ApiCancelKernelSessionRequest,
     ApiGetAcceleratorQuotaStatisticsRequest,
 )
 from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType
@@ -7331,6 +7332,31 @@ class KaggleApi:
             print('Failure message: "%s"' % message)
         else:
             print('%s has status "%s"' % (kernel, status))
+
+    def kernels_cancel(self, session_id: int):
+        """Request cancellation of one kernel session by its numeric identity.
+
+        Args:
+            session_id: Numeric session ID accepted by the cancel-session API.
+
+        Returns:
+            The cancel-session API response.
+        """
+        if session_id <= 0:
+            raise ValueError("A kernel session ID must be positive")
+
+        with self.build_kaggle_client() as kaggle:
+            request = ApiCancelKernelSessionRequest()
+            request.kernel_session_id = session_id
+            return kaggle.kernels.kernels_api_client.cancel_kernel_session(request)
+
+    def kernels_cancel_cli(self, session_id: int) -> None:
+        """Cancel one kernel session and print the API result."""
+        response = self.kernels_cancel(session_id)
+        if response.error_message:
+            print(f"Cancel failed: {response.error_message}")
+        else:
+            print(f"Cancellation requested for kernel session {session_id}.")
 
     def kernels_logs(self, kernel: str | None) -> str:
         """Retrieves the execution log for a specified kernel.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1437,6 +1437,17 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_status._action_groups.append(parser_kernels_status_optional)
     parser_kernels_status.set_defaults(func=api.kernels_status_cli)
 
+    # Kernels cancel
+    parser_kernels_cancel = subparsers_kernels.add_parser(
+        "cancel", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_kernels_cancel
+    )
+    parser_kernels_cancel_optional = parser_kernels_cancel._action_groups.pop()
+    parser_kernels_cancel_optional.add_argument(
+        "--session-id", dest="session_id", required=True, type=int, help=Help.param_kernel_session_id
+    )
+    parser_kernels_cancel._action_groups.append(parser_kernels_cancel_optional)
+    parser_kernels_cancel.set_defaults(func=api.kernels_cancel_cli)
+
     # Kernels logs
     parser_kernels_logs = subparsers_kernels.add_parser(
         "logs", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_kernels_logs
@@ -2548,6 +2559,7 @@ class Help(object):
         "pull",
         "output",
         "status",
+        "cancel",
         "logs",
         "update",
         "delete",
@@ -2710,6 +2722,7 @@ class Help(object):
     command_kernels_pull = "Pull down code from a kernel"
     command_kernels_output = "Get data output from the latest kernel run"
     command_kernels_status = "Display the status of the latest kernel run"
+    command_kernels_cancel = "Cancel one kernel session by session ID"
     command_kernels_logs = "Print the execution logs from the latest kernel run"
     command_kernels_delete = "Delete a kernel"
     command_kernels_topics = "List discussion topics for a kernel"
@@ -2934,6 +2947,7 @@ class Help(object):
     param_kernel_type = (
         "Specify the type of kernel. Default is 'all'. Valid " "options are 'all', 'script', and 'notebook'"
     )
+    param_kernel_session_id = "Numeric ID of the kernel session to cancel"
     param_kernel_output_type = (
         "Search for specific kernel output types. "
         "Default is 'all'.  Valid options are 'all', "

--- a/tests/unit/test_cli_kernels.py
+++ b/tests/unit/test_cli_kernels.py
@@ -247,6 +247,13 @@ def test_kernels_status_parser_with_option_kernel_succeeds(parser):
     assert kwargs["kernel_opt"] == "owner/kernel-name"
 
 
+def test_kernels_cancel_parser_uses_an_explicit_session_id(parser):
+    func, kwargs = parser.dispatch(["kernels", "cancel", "--session-id", "123"])
+
+    assert func.__name__ == "kernels_cancel_cli"
+    assert kwargs["session_id"] == 123
+
+
 def test_kernels_logs_parser_default_succeeds(parser):
     func, kwargs = parser.dispatch(["kernels", "logs"])
     assert func.__name__ == "kernels_logs_cli"

--- a/tests/unit/test_kernels_cancel.py
+++ b/tests/unit/test_kernels_cancel.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+from unittest.mock import MagicMock
+
+import pytest
+from kagglesdk.kernels.types.kernels_api_service import ApiCancelKernelSessionResponse
+
+
+def test_kernels_cancel_calls_the_supported_session_endpoint(api):
+    """The CLI adapter must not depend on the undocumented editor API."""
+    response = ApiCancelKernelSessionResponse()
+    kaggle_client = MagicMock()
+    kaggle_client.kernels.kernels_api_client.cancel_kernel_session.return_value = response
+    api.build_kaggle_client.return_value.__enter__.return_value = kaggle_client
+
+    result = api.kernels_cancel(123)
+
+    assert result is response
+    request = kaggle_client.kernels.kernels_api_client.cancel_kernel_session.call_args.args[0]
+    assert request.kernel_session_id == 123
+
+
+def test_kernels_cancel_rejects_a_non_positive_session_id(api):
+    """Fail locally before a malformed cancellation request reaches Kaggle."""
+    with pytest.raises(ValueError, match="positive"):
+        api.kernels_cancel(0)
+
+    api.build_kaggle_client.assert_not_called()
+
+
+def test_kernels_cancel_cli_reports_the_server_error(api, capsys, monkeypatch):
+    """The operator receives the cancel endpoint's actionable error text."""
+    response = ApiCancelKernelSessionResponse()
+    response.error_message = "The session is already complete."
+    monkeypatch.setattr(api, "kernels_cancel", MagicMock(return_value=response))
+
+    api.kernels_cancel_cli(123)
+
+    assert capsys.readouterr().out == "Cancel failed: The session is already complete.\n"
+
+
+def test_kernels_cancel_cli_confirms_the_requested_session(api, capsys, monkeypatch):
+    """Success output remains scoped to the numeric session the user selected."""
+    monkeypatch.setattr(api, "kernels_cancel", MagicMock(return_value=ApiCancelKernelSessionResponse()))
+
+    api.kernels_cancel_cli(123)
+
+    assert capsys.readouterr().out == "Cancellation requested for kernel session 123.\n"


### PR DESCRIPTION
## Summary

- add `kaggle kernels cancel --session-id SESSION_ID`
- call the existing public `cancel_kernel_session` SDK endpoint
- document the command and cover parser, request construction, local validation, and API error output

## Why

The CLI exposes kernel status, logs, and outputs but not cancellation. The public status and kernel APIs do not return a session ID, so this deliberately accepts the numeric ID rather than relying on the undocumented editor API. This is the supported, testable portion of #1169.

## Validation

- `pytest tests/unit` — 1256 passed
- `black --check --diff .`
- `mypy src/kaggle tests`
- invoked the new command against a completed private CPU probe session

Closes #1169.
