### PR TITLE
feat(kernels): add kernels run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Add `kaggle kernels run` to push a kernel and wait for the run to finish, with optional output download (`--output`, `--file-pattern`), `--wait-timeout`/`--poll-interval` controls, and CI-friendly exit codes (0 on completion, 1 on failure/cancellation/timeout)
 * Add `kaggle competitions host-add <comp> -u <user>` to grant host access on a competition to a Kaggle user
 * Suggest a next step on 403/404/429/5xx API errors, report unexpected errors as bugs instead of a traceback (with a new `--debug` flag), and list common examples in `kaggle --help`
 * Add `kaggle benchmarks quota` to show Model Proxy (AI inference) spend quota, and bump `kagglesdk` to `>= 0.1.37`

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -170,6 +170,53 @@ Some of these are only available to participants of specific competitions, and s
 > [!WARNING]
 > `NvidiaTeslaP100` is not usable for GPU compute with the default Kaggle image. Its PyTorch build (cu128) does not include Pascal (`sm_60`) kernels, so `torch.cuda.is_available()` returns `True` but the first CUDA operation fails with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` instead, or install a Pascal-compatible torch build if you require a P100.
 
+## `kaggle kernels run`
+
+Pushes new code/notebook and metadata to a kernel (exactly like `kaggle kernels push`), then waits for the resulting run to finish. Optionally downloads the run's output files, and exits with code 0 when the run completes or 1 when it fails, is cancelled, or the wait times out — so scripts and CI pipelines can gate on the result.
+
+**Usage:**
+
+```bash
+kaggle kernels run [-p <FOLDER_PATH>] [options]
+```
+
+**Options:**
+
+*   `-p, --path <FOLDER_PATH>`: Path to the folder containing the kernel file and the `kernel-metadata.json` file (defaults to the current directory).
+*   `-t, --timeout <SECONDS>`: Maximum run time in seconds (server-side session limit, as for `push`).
+*   `--accelerator <ACCELERATOR_ID>`: Accelerator to use during the run (as for `push`).
+*   `--wait-timeout <SECONDS>`: Maximum seconds to wait for the run to finish. Defaults to 12 hours, the maximum notebook runtime. On timeout the run keeps executing on Kaggle and the command tells you how to check on it later.
+*   `--poll-interval <SECONDS>`: Maximum seconds between status polls (default 30; polling starts at 5s and backs off adaptively up to this cap).
+*   `--output <FOLDER>`: Download the run's output files to this directory after it completes. When omitted, outputs are not downloaded.
+*   `--file-pattern <REGEX>`: Only download output files matching this regex (requires `--output`).
+*   `--force`: Overwrite existing files when downloading outputs (requires `--output`).
+*   `-q, --quiet`: Suppress progress output.
+
+**Example:**
+
+Run a notebook and collect its outputs, failing the shell command if the notebook raises:
+
+```bash
+kaggle kernels run -p . --output ./results
+echo $?   # 0 when the run completed, 1 when it failed
+```
+
+Typical CI usage with a bounded wait:
+
+```bash
+kaggle kernels run -p . --wait-timeout 7200 --poll-interval 30 \
+    --output ./artifacts --file-pattern 'submission\.csv' --quiet
+```
+
+**Purpose:**
+
+`kaggle kernels push` is fire-and-forget: it starts a run and returns immediately. `kaggle kernels run` is the synchronous version — push, wait for the session to reach a terminal state, surface the failure message if the run errored, and optionally fetch the outputs — replacing hand-written loops around `kaggle kernels status`.
+
+> [!NOTE]
+> The Kaggle API reports the status and outputs of a kernel's *latest* session only. `kaggle kernels run` guards against reading the previous session's status right after a push, but pushing another version of the same kernel while a run is being waited on is not supported — the wait would attach to the newest session.
+
+To watch the run's log output while it executes, use `kaggle kernels logs <KERNEL> --follow` in another terminal.
+
 ## `kaggle kernels pull`
 
 Pulls down the code/notebook and metadata for a kernel.

--- a/skills/references/kernels.md
+++ b/skills/references/kernels.md
@@ -19,6 +19,7 @@ kaggle kernels (alias: kaggle k)
 ├── files
 ├── init
 ├── push | update
+├── run
 ├── pull | get
 ├── output
 ├── status
@@ -140,6 +141,47 @@ Kaggle image, whose PyTorch build (cu128) omits Pascal (`sm_60`) kernels:
 `torch.cuda.is_available()` returns `True`, but the first CUDA operation fails
 with `cudaErrorNoKernelImageForDevice`. Use `NvidiaTeslaT4` or
 install a Pascal-compatible torch build.
+
+## `kaggle kernels run`
+
+Pushes code to a kernel (like `push`), waits for the run to finish, and
+optionally downloads its outputs. Exits 0 when the run completes, 1 when it
+fails, is cancelled, or the wait times out.
+
+**Usage:**
+
+```bash
+kaggle kernels run [options]
+```
+
+**Options:**
+
+- `-p, --path <FOLDER>`: Folder containing files and `kernel-metadata.json`.
+- `-t, --timeout <SECONDS>`: Server-side run time limit (as for `push`).
+- `--accelerator <ACCELERATOR>`: Accelerator type (as for `push`).
+- `--wait-timeout <SECONDS>`: Client-side wait cap; defaults to 12 hours.
+- `--poll-interval <SECONDS>`: Max seconds between status polls (default 30).
+- `--output <FOLDER>`: Download the run's outputs here after completion.
+- `--file-pattern <REGEX>`: Only download matching outputs (needs `--output`).
+- `--force`: Overwrite existing output files (needs `--output`).
+- `-q, --quiet`: Suppress progress output.
+
+**Examples:**
+
+```bash
+kaggle kernels run -p my-kernel --output results
+kaggle kernels run -p . --wait-timeout 7200 --file-pattern 'submission\.csv' --output artifacts -q
+```
+
+**Purpose:** Synchronous version of `push` for scripting and CI: push, poll
+the run to a terminal state, surface the failure message on error, fetch
+outputs, and gate on the exit code.
+
+**Notes:** The API reports only the kernel's latest session, so do not push
+another version of the same kernel while a run is being waited on. On timeout
+or Ctrl+C the run keeps executing on Kaggle; the command prints the
+`kernels status` / `kernels output` commands to check on it later. Use
+`kaggle kernels logs <KERNEL> --follow` in another terminal to watch logs live.
 
 ## `kaggle kernels pull`
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -37,6 +37,7 @@ import tarfile
 import tempfile
 import time
 import zipfile
+from urllib.parse import urlparse
 from dateutil.relativedelta import relativedelta
 from os.path import expanduser
 from random import random
@@ -216,7 +217,7 @@ from kagglesdk.kernels.types.kernels_api_service import (
     ApiDeleteKernelRequest,
     ApiGetAcceleratorQuotaStatisticsRequest,
 )
-from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType
+from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType, KernelWorkerStatus
 from kagglesdk.models.types.model_api_service import (
     ApiListModelsRequest,
     ApiCreateModelRequest,
@@ -960,6 +961,25 @@ class FileList(object):
 
     def __repr__(self):
         return ""
+
+
+class KernelRunResult:
+    """The outcome of a synchronous kernel run (see KaggleApi.kernels_run)."""
+
+    def __init__(self, status, version_number, url, ref=None, output_files=None, elapsed_seconds=None):
+        self.status = status
+        self.version_number = version_number
+        self.url = url
+        self.ref = ref  # 'owner/slug' of the kernel that was run
+        self.output_files = output_files if output_files is not None else []
+        self.elapsed_seconds = elapsed_seconds
+
+    def __repr__(self):
+        return "KernelRunResult(status=%s, version_number=%s, url=%s)" % (
+            getattr(self.status, "name", self.status),
+            self.version_number,
+            self.url,
+        )
 
 
 ISSUE_TRACKER_URL = "https://github.com/Kaggle/kaggle-cli/issues"
@@ -7503,6 +7523,287 @@ class KaggleApi:
             print('Failure message: "%s"' % message)
         else:
             print('%s has status "%s"' % (kernel, status))
+
+    # How long a just-pushed kernel may keep reporting the previous session's
+    # terminal status before we trust what we see. In practice the push
+    # creates and enqueues the new session synchronously (verified against the
+    # live API), so this is a defensive bound, not an expected wait.
+    _SESSION_START_GRACE_SECONDS = 60
+
+    def _poll_kernel_session(self, kernel, wait, poll_interval, quiet=False, baseline_status=None):
+        """Polls a kernel's latest session until it finishes or the wait times out.
+
+        Reuses the shared adaptive-backoff (``_adaptive_sleep``) infrastructure,
+        mirroring ``_poll_submission``. A transient 404 (e.g. a brand-new kernel
+        whose session is not visible yet) is treated as pending while still
+        inside the wait window rather than being surfaced as an error.
+
+        The Kaggle API only reports the status of a kernel's *latest* session,
+        so callers that just pushed should pass the pre-push status as
+        ``baseline_status``: an identical terminal status observed before any
+        active status is then treated as possibly stale for a short grace
+        period instead of being accepted as this run's result.
+
+        Args:
+            kernel: The kernel in 'owner/slug' form.
+            wait: 0 waits indefinitely; a positive value is a timeout in seconds.
+            poll_interval: Maximum seconds between polls (adaptive up to this cap).
+            quiet: Suppress per-poll status output (default is False).
+            baseline_status: The kernel's status before the push, if any.
+
+        Returns:
+            ApiGetKernelSessionStatusResponse: The response once the session
+            reaches COMPLETE.
+
+        Raises:
+            ValueError: If the session finishes in ERROR, is cancelled, or the
+                wait times out.
+        """
+        start_time = time.time()
+        current_interval = min(self._ADAPTIVE_POLL_START, poll_interval)
+        seen_active = baseline_status is None
+        try:
+            while True:
+                try:
+                    response = self.kernels_status(kernel)
+                    status = response.status
+                except HTTPError as e:
+                    # A freshly pushed kernel may not be visible yet; keep
+                    # waiting rather than failing.
+                    if e.response is not None and e.response.status_code == 404:
+                        response = None
+                        status = None
+                    else:
+                        raise
+
+                if status in (
+                    KernelWorkerStatus.QUEUED,
+                    KernelWorkerStatus.RUNNING,
+                    KernelWorkerStatus.NEW_SCRIPT,
+                    KernelWorkerStatus.CANCEL_REQUESTED,
+                ):
+                    # The new session is visible; any terminal status from here
+                    # on belongs to this run.
+                    seen_active = True
+
+                possibly_stale = (
+                    not seen_active
+                    and status == baseline_status
+                    and (time.time() - start_time) < self._SESSION_START_GRACE_SECONDS
+                )
+
+                if not possibly_stale:
+                    if status == KernelWorkerStatus.COMPLETE:
+                        return response
+                    if status == KernelWorkerStatus.ERROR:
+                        message = (response.failure_message or "").strip() or "No error message provided."
+                        raise ValueError("Kernel run %s failed.\n  Error: %s" % (kernel, message))
+                    if status == KernelWorkerStatus.CANCEL_ACKNOWLEDGED:
+                        raise ValueError("Kernel run %s was cancelled on kaggle.com." % kernel)
+
+                if not quiet:
+                    print("Session status: %s..." % (status.name if status else "PENDING"))
+
+                if wait > 0 and (time.time() - start_time) > wait:
+                    raise ValueError(
+                        "Timed out after %ss waiting for the kernel run %s to finish.\n"
+                        "The session keeps running on Kaggle.\n"
+                        "Check status with: kaggle kernels status %s\n"
+                        "Fetch outputs with: kaggle kernels output %s" % (wait, kernel, kernel, kernel)
+                    )
+
+                current_interval = self._adaptive_sleep(current_interval, poll_interval)
+        except KeyboardInterrupt:
+            print(
+                "\nStopped waiting for the kernel run %s. The session keeps running on Kaggle.\n"
+                "Check status with: kaggle kernels status %s\n"
+                "Fetch outputs with: kaggle kernels output %s" % (kernel, kernel, kernel)
+            )
+            raise
+
+    def _kernel_ref_from_folder(self, folder):
+        """Resolves (owner_slug, kernel_slug) from a kernel folder's metadata.
+
+        Returns None when the metadata file is missing, has no 'id', or still
+        carries the init placeholder.
+        """
+        meta_file = os.path.join(folder, self.KERNEL_METADATA_FILE)
+        if not os.path.isfile(meta_file):
+            return None
+        with open(meta_file, encoding="utf-8") as f:
+            meta_data = json.load(f)
+        slug = meta_data.get("id")
+        if not slug or "INSERT_KERNEL_SLUG_HERE" in slug:
+            return None
+        owner_slug, kernel_slug, _ = self.parse_kernel_string(slug)
+        return owner_slug, kernel_slug
+
+    def _kernel_ref_from_push(self, folder, response):
+        """Resolves (owner_slug, kernel_slug) for a just-pushed kernel.
+
+        Prefers the metadata file's 'id'; falls back to the URL in the push
+        response for metadata that only carries a numeric 'id_no'.
+
+        Args:
+            folder: The folder that was pushed (contains the metadata file).
+            response (ApiSaveKernelResponse): The push response.
+
+        Returns:
+            Tuple[str, str]: The owner slug and kernel slug.
+        """
+        ref = self._kernel_ref_from_folder(folder)
+        if ref is not None:
+            return ref
+        url_path = urlparse(response.url).path if response.url else ""
+        parts = [part for part in url_path.split("/") if part and part != "code"]
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+        raise ValueError(
+            "Could not determine the kernel's owner/slug from the metadata or "
+            "the push response. Add an 'id' (\"owner/kernel-slug\") to %s" % self.KERNEL_METADATA_FILE
+        )
+
+    def kernels_run(
+        self,
+        folder: str,
+        timeout: Optional[str] = None,
+        acc: Optional[str] = None,
+        wait_timeout: Optional[int] = None,
+        poll_interval: int = 30,
+        output_path: Optional[str] = None,
+        file_pattern: Optional[str] = None,
+        force: bool = False,
+        quiet: bool = False,
+    ) -> KernelRunResult:
+        """Pushes a kernel and waits for the resulting session to finish.
+
+        The Kaggle API only reports the status and outputs of a kernel's
+        *latest* session, so this method observes that session, guarding
+        against reading the previous session's terminal status right after the
+        push. Pushing another version of the same kernel while a run is being
+        waited on is not supported: the wait would attach to the newest
+        session.
+
+        Args:
+            folder (str): The path to the kernel folder (with a metadata file).
+            timeout (Optional[str]): Server-side maximum run time in seconds
+                (same as ``kernels push --timeout``).
+            acc (Optional[str]): The accelerator to use (same as
+                ``kernels push --accelerator``).
+            wait_timeout (Optional[int]): Client-side wait cap in seconds.
+                None or 0 waits up to 12 hours, the maximum notebook runtime.
+            poll_interval (int): Maximum seconds between status polls
+                (default is 30, adaptive from 5s up to this cap).
+            output_path (Optional[str]): If set, download the session's output
+                files to this directory after it completes.
+            file_pattern (Optional[str]): Optional regex filter for the output
+                download; requires output_path.
+            force (bool): Force-overwrite existing output files (default is
+                False); requires output_path.
+            quiet (bool): Suppress progress output (default is False).
+
+        Returns:
+            KernelRunResult: The terminal status, version number, kernel URL,
+            downloaded output files, and elapsed seconds.
+
+        Raises:
+            ValueError: If the push is rejected, the session fails or is
+                cancelled, the wait times out, or an output download fails.
+        """
+        if file_pattern is not None and output_path is None:
+            raise ValueError("--file-pattern requires --output")
+        if force and output_path is None:
+            raise ValueError("--force requires --output")
+        if poll_interval < self._MIN_POLL_INTERVAL:
+            raise ValueError(
+                "--poll-interval must be at least %ss to avoid overloading Kaggle's servers." % self._MIN_POLL_INTERVAL
+            )
+        if wait_timeout is not None and wait_timeout < 0:
+            raise ValueError("--wait-timeout cannot be negative.")
+        # "Wait indefinitely" (None or 0) is capped at the 12h maximum notebook
+        # runtime, mirroring `competitions submit --wait`.
+        if not wait_timeout:
+            wait_timeout = self._DEFAULT_WAIT_TIMEOUT
+
+        start_time = time.time()
+
+        # The status endpoint only reports the latest session, so read the
+        # pre-push status: if the first post-push polls still show the same
+        # terminal status, _poll_kernel_session holds off accepting it as this
+        # run's result for a short grace period.
+        baseline_status = None
+        ref = self._kernel_ref_from_folder(folder)
+        if ref is not None:
+            try:
+                baseline_status = self.kernels_status("%s/%s" % ref).status
+            except (HTTPError, ValueError):
+                baseline_status = None  # Never run or not visible: nothing to confuse with.
+
+        response = self.kernels_push(folder, timeout, acc)
+        if response.error:
+            raise ValueError("Kernel push error: " + response.error)
+        version_number = response.version_number
+
+        if ref is None:
+            ref = self._kernel_ref_from_push(folder, response)
+        kernel_ref = "%s/%s" % ref
+        if not quiet:
+            print("Kernel version %s pushed: %s" % (version_number or "?", response.url))
+
+        session = self._poll_kernel_session(
+            kernel_ref, wait_timeout, poll_interval, quiet, baseline_status=baseline_status
+        )
+
+        elapsed = time.time() - start_time
+        if not quiet:
+            minutes, seconds = divmod(int(elapsed), 60)
+            print("Session for version %s complete in %dm%02ds." % (version_number or "?", minutes, seconds))
+
+        output_files: List[str] = []
+        if output_path:
+            output_files, _ = self.kernels_output(
+                kernel_ref, output_path, file_pattern=file_pattern, force=force, quiet=quiet
+            )
+
+        return KernelRunResult(
+            status=session.status,
+            version_number=version_number,
+            url=response.url,
+            ref=kernel_ref,
+            output_files=output_files,
+            elapsed_seconds=elapsed,
+        )
+
+    def kernels_run_cli(
+        self,
+        folder=None,
+        timeout=None,
+        acc=None,
+        wait_timeout=None,
+        poll_interval=30,
+        output_path=None,
+        file_pattern=None,
+        force=False,
+        quiet=False,
+    ):
+        """A client wrapper for kernels_run.
+
+        Please see the kernels_run function for a description of the arguments.
+        """
+        folder = folder or os.getcwd()
+        result = self.kernels_run(
+            folder,
+            timeout,
+            acc,
+            wait_timeout,
+            poll_interval,
+            output_path,
+            file_pattern,
+            force,
+            quiet,
+        )
+        if not quiet and output_path is None:
+            print("Fetch outputs with: kaggle kernels output %s" % result.ref)
 
     def kernels_logs(self, kernel: str | None) -> str:
         """Retrieves the execution log for a specified kernel.

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1422,6 +1422,49 @@ def parse_kernels(subparsers) -> None:
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 
+    # Kernels run
+    parser_kernels_run = subparsers_kernels.add_parser(
+        "run", formatter_class=argparse.RawTextHelpFormatter, help=Help.command_kernels_run
+    )
+    parser_kernels_run_optional = parser_kernels_run._action_groups.pop()
+    parser_kernels_run_optional.add_argument(
+        "-p", "--path", dest="folder", required=False, help=Help.param_kernel_upfile
+    )
+    parser_kernels_run_optional.add_argument(
+        "-t", "--timeout", type=int, dest="timeout", help=Help.param_kernel_timeout
+    )
+    parser_kernels_run_optional.add_argument("--accelerator", dest="acc", help=Help.param_kernel_acc)
+    parser_kernels_run_optional.add_argument(
+        "--wait-timeout",
+        dest="wait_timeout",
+        type=int,
+        default=None,
+        required=False,
+        help=Help.param_kernel_run_wait_timeout,
+    )
+    parser_kernels_run_optional.add_argument(
+        "--poll-interval",
+        dest="poll_interval",
+        type=int,
+        default=30,
+        required=False,
+        help=Help.param_kernel_run_poll_interval,
+    )
+    parser_kernels_run_optional.add_argument(
+        "--output", dest="output_path", required=False, help=Help.param_kernel_run_output
+    )
+    parser_kernels_run_optional.add_argument(
+        "--file-pattern", dest="file_pattern", required=False, help=Help.param_kernel_output_file_pattern
+    )
+    parser_kernels_run_optional.add_argument(
+        "--force", dest="force", action="store_true", required=False, help=Help.param_force
+    )
+    parser_kernels_run_optional.add_argument(
+        "-q", "--quiet", dest="quiet", action="store_true", required=False, help=Help.param_quiet
+    )
+    parser_kernels_run._action_groups.append(parser_kernels_run_optional)
+    parser_kernels_run.set_defaults(func=api.kernels_run_cli)
+
     # Kernels pull
     parser_kernels_pull = subparsers_kernels.add_parser(
         "pull",
@@ -2594,6 +2637,7 @@ class Help(object):
         "get",
         "init",
         "push",
+        "run",
         "pull",
         "output",
         "status",
@@ -2777,6 +2821,7 @@ options a specific command accepts."""
     command_kernels_files = "List kernel output files"
     command_kernels_init = "Initialize metadata file for a kernel"
     command_kernels_push = "Push new code to a kernel and run the kernel"
+    command_kernels_run = "Push new code to a kernel and wait for the run to finish"
     command_kernels_pull = "Pull down code from a kernel"
     command_kernels_output = "Get data output from the latest kernel run"
     command_kernels_status = "Display the status of the latest kernel run"
@@ -2994,6 +3039,18 @@ options a specific command accepts."""
         "Limit the run time of a kernel to the given number "
         "of seconds. The global maximum time will not be "
         "exceeded."
+    )
+    param_kernel_run_wait_timeout = (
+        "Maximum seconds to wait for the kernel run to finish "
+        "(0 or omit = wait up to 12 hours, the maximum notebook runtime)"
+    )
+    param_kernel_run_poll_interval = (
+        "Maximum seconds between status polls while waiting (default: 30, minimum: 5). "
+        "Polling starts at 5s and increases automatically"
+    )
+    param_kernel_run_output = (
+        "Download the run's output files to this directory after it "
+        "completes. When omitted, outputs are not downloaded"
     )
     param_kernel_user = "Find kernels created by a given username"
     # TODO(b/129357583): Pull these from the same spot as the api impl

--- a/tests/backend/backend_tests.py
+++ b/tests/backend/backend_tests.py
@@ -328,6 +328,26 @@ class TestKaggleApi(unittest.TestCase):
         finally:
             shutil.rmtree(fs)
 
+    def test_kernels_ga_run(self):
+        if self.kernel_metadata_path == "":
+            self.test_kernels_b_initialize()
+        output_files: list[str] = []
+        try:
+            update_kernel_metadata_file(self.kernel_metadata_path, kernel_name)
+            result = api.kernels_run(kernel_directory, wait_timeout=600, poll_interval=5, output_path="kernel/tmp")
+            self.assertEqual(KernelWorkerStatus.COMPLETE, result.status)
+            self.assertTrue(isinstance(result.version_number, int))
+            self.assertIsInstance(result.output_files, list)
+            output_files = result.output_files
+        except ApiException as e:
+            self.fail(f"kernels_run failed: {e}")
+        finally:
+            for file in output_files:
+                if os.path.exists(file):
+                    os.remove(file)
+            if os.path.exists("kernel/tmp"):
+                os.rmdir("kernel/tmp")
+
     # Competitions
 
     def test_competition_a_list(self):

--- a/tests/unit/test_cli_kernels.py
+++ b/tests/unit/test_cli_kernels.py
@@ -320,3 +320,52 @@ def test_kernels_topics_show_two_args_succeeds(parser):
     assert func.__name__ == "forums_topic_show_cli"
     assert kwargs["topic_ref"] == "owner/kernel-name"
     assert kwargs["topic_id_arg"] == 12345
+
+
+def test_kernels_run_parser_defaults_succeeds(parser):
+    func, kwargs = parser.dispatch(["kernels", "run"])
+    assert func.__name__ == "kernels_run_cli"
+    assert kwargs.get("folder") is None
+    assert kwargs.get("timeout") is None
+    assert kwargs.get("acc") is None
+    assert kwargs.get("wait_timeout") is None
+    assert kwargs.get("poll_interval") == 30
+    assert kwargs.get("output_path") is None
+    assert kwargs.get("file_pattern") is None
+    assert kwargs.get("force") is False
+    assert kwargs.get("quiet") is False
+
+
+def test_kernels_run_parser_with_flags_succeeds(parser):
+    func, kwargs = parser.dispatch(
+        [
+            "kernels",
+            "run",
+            "-p",
+            "my-folder",
+            "--timeout",
+            "3600",
+            "--accelerator",
+            "NvidiaTeslaT4",
+            "--wait-timeout",
+            "7200",
+            "--poll-interval",
+            "45",
+            "--output",
+            "results-dir",
+            "--file-pattern",
+            "submission\\.csv",
+            "--force",
+            "--quiet",
+        ]
+    )
+    assert func.__name__ == "kernels_run_cli"
+    assert kwargs["folder"] == "my-folder"
+    assert kwargs["timeout"] == 3600
+    assert kwargs["acc"] == "NvidiaTeslaT4"
+    assert kwargs["wait_timeout"] == 7200
+    assert kwargs["poll_interval"] == 45
+    assert kwargs["output_path"] == "results-dir"
+    assert kwargs["file_pattern"] == "submission\\.csv"
+    assert kwargs["force"] is True
+    assert kwargs["quiet"] is True

--- a/tests/unit/test_kernels_run.py
+++ b/tests/unit/test_kernels_run.py
@@ -1,0 +1,360 @@
+# coding=utf-8
+"""Tests for `kernels run` (kernels_run / _poll_kernel_session).
+
+Covers the session polling helper (terminal states, transient 404s, the
+stale-baseline guard, timeouts), the push-then-wait flow, output download
+wiring, argument validation, and the owner/slug resolution fallbacks.
+
+The Kaggle API only reports a kernel's *latest* session (version-pinned
+status/output lookups are not supported by the backend), so the poll guards
+against reading the previous session's terminal status right after a push by
+comparing against a pre-push baseline status.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from kaggle.api.kaggle_api_extended import KaggleApi, KernelRunResult
+from kagglesdk.kernels.types.kernels_api_service import ApiGetKernelSessionStatusResponse
+from kagglesdk.kernels.types.kernels_enums import KernelWorkerStatus
+
+
+def _api():
+    """A bare KaggleApi instance without running __init__/authenticate."""
+    api = KaggleApi.__new__(KaggleApi)
+    api.config_values = {"username": "testuser"}
+    api.already_printed_version_warning = True
+    return api
+
+
+def _status(status, failure_message=None):
+    response = ApiGetKernelSessionStatusResponse()
+    response.status = status
+    if failure_message is not None:
+        response.failure_message = failure_message
+    return response
+
+
+def _http_error(code):
+    return HTTPError(response=MagicMock(status_code=code))
+
+
+def _no_sleep():
+    """Patch the adaptive sleep so polls advance instantly."""
+    return patch.object(KaggleApi, "_adaptive_sleep", side_effect=lambda current, cap, verbose=False: cap)
+
+
+def _push_response(version_number=7, url="https://www.kaggle.com/code/testuser/my-kernel", error=None):
+    response = MagicMock()
+    response.error = error
+    response.version_number = version_number
+    response.url = url
+    return response
+
+
+# --------------------------------------------------------------------------
+# _poll_kernel_session
+# --------------------------------------------------------------------------
+def test_poll_completes_after_queued_and_running():
+    api = _api()
+    statuses = [
+        _status(KernelWorkerStatus.QUEUED),
+        _status(KernelWorkerStatus.RUNNING),
+        _status(KernelWorkerStatus.COMPLETE),
+    ]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses) as status_mock, _no_sleep():
+        response = api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+    assert response.status == KernelWorkerStatus.COMPLETE
+    assert status_mock.call_count == 3
+
+
+def test_poll_error_raises_with_failure_message():
+    api = _api()
+    statuses = [
+        _status(KernelWorkerStatus.RUNNING),
+        _status(KernelWorkerStatus.ERROR, failure_message="Boom"),
+    ]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses), _no_sleep():
+        with pytest.raises(ValueError, match="Boom"):
+            api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+
+
+def test_poll_error_without_message_uses_fallback():
+    api = _api()
+    with patch.object(KaggleApi, "kernels_status", side_effect=[_status(KernelWorkerStatus.ERROR)]), _no_sleep():
+        with pytest.raises(ValueError, match="No error message provided"):
+            api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+
+
+def test_poll_cancel_acknowledged_raises():
+    api = _api()
+    statuses = [
+        _status(KernelWorkerStatus.CANCEL_REQUESTED),
+        _status(KernelWorkerStatus.CANCEL_ACKNOWLEDGED),
+    ]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses), _no_sleep():
+        with pytest.raises(ValueError, match="cancelled"):
+            api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+
+
+def test_poll_transient_404_treated_as_pending():
+    api = _api()
+    statuses = [_http_error(404), _status(KernelWorkerStatus.RUNNING), _status(KernelWorkerStatus.COMPLETE)]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses) as status_mock, _no_sleep():
+        response = api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+    assert response.status == KernelWorkerStatus.COMPLETE
+    assert status_mock.call_count == 3
+
+
+def test_poll_non_404_http_error_propagates():
+    api = _api()
+    with patch.object(KaggleApi, "kernels_status", side_effect=[_http_error(500)]), _no_sleep():
+        with pytest.raises(HTTPError):
+            api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+
+
+def test_poll_timeout_raises_with_recovery_hint():
+    api = _api()
+    with patch.object(KaggleApi, "kernels_status", return_value=_status(KernelWorkerStatus.RUNNING)), _no_sleep():
+        with pytest.raises(ValueError, match="kaggle kernels status testuser/my-kernel"):
+            api._poll_kernel_session("testuser/my-kernel", wait=1e-9, poll_interval=30, quiet=True)
+
+
+def test_poll_stale_baseline_terminal_is_not_accepted():
+    """A COMPLETE identical to the pre-push status must not be trusted until
+    an active status proves the new session is the one being observed."""
+    api = _api()
+    statuses = [
+        _status(KernelWorkerStatus.COMPLETE),  # stale: previous session
+        _status(KernelWorkerStatus.COMPLETE),  # still stale
+        _status(KernelWorkerStatus.RUNNING),  # new session visible
+        _status(KernelWorkerStatus.COMPLETE),  # this run's result
+    ]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses) as status_mock, _no_sleep():
+        response = api._poll_kernel_session(
+            "testuser/my-kernel",
+            wait=0,
+            poll_interval=30,
+            quiet=True,
+            baseline_status=KernelWorkerStatus.COMPLETE,
+        )
+    assert response.status == KernelWorkerStatus.COMPLETE
+    assert status_mock.call_count == 4
+
+
+def test_poll_stale_guard_expires_after_grace():
+    api = _api()
+    api._SESSION_START_GRACE_SECONDS = 0  # disable the guard window
+    with patch.object(KaggleApi, "kernels_status", side_effect=[_status(KernelWorkerStatus.COMPLETE)]), _no_sleep():
+        response = api._poll_kernel_session(
+            "testuser/my-kernel",
+            wait=0,
+            poll_interval=30,
+            quiet=True,
+            baseline_status=KernelWorkerStatus.COMPLETE,
+        )
+    assert response.status == KernelWorkerStatus.COMPLETE
+
+
+def test_poll_terminal_differing_from_baseline_accepted_immediately():
+    api = _api()
+    statuses = [_status(KernelWorkerStatus.ERROR, failure_message="new failure")]
+    with patch.object(KaggleApi, "kernels_status", side_effect=statuses), _no_sleep():
+        with pytest.raises(ValueError, match="new failure"):
+            api._poll_kernel_session(
+                "testuser/my-kernel",
+                wait=0,
+                poll_interval=30,
+                quiet=True,
+                baseline_status=KernelWorkerStatus.COMPLETE,
+            )
+
+
+def test_poll_without_baseline_accepts_first_terminal():
+    api = _api()
+    with patch.object(KaggleApi, "kernels_status", side_effect=[_status(KernelWorkerStatus.COMPLETE)]), _no_sleep():
+        response = api._poll_kernel_session("testuser/my-kernel", wait=0, poll_interval=30, quiet=True)
+    assert response.status == KernelWorkerStatus.COMPLETE
+
+
+# --------------------------------------------------------------------------
+# kernels_run
+# --------------------------------------------------------------------------
+def test_run_happy_path_with_output():
+    api = _api()
+    with (
+        patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=("testuser", "my-kernel")),
+        patch.object(KaggleApi, "kernels_status", return_value=_status(KernelWorkerStatus.COMPLETE)),
+        patch.object(KaggleApi, "kernels_push", return_value=_push_response()) as push_mock,
+        patch.object(KaggleApi, "_poll_kernel_session", return_value=_status(KernelWorkerStatus.COMPLETE)) as poll_mock,
+        patch.object(KaggleApi, "kernels_output", return_value=(["/tmp/out/sub.csv"], None)) as output_mock,
+    ):
+        result = api.kernels_run("/tmp/folder", output_path="/tmp/out", quiet=True)
+
+    push_mock.assert_called_once_with("/tmp/folder", None, None)
+    # The pre-push status is passed to the poll as the stale-detection baseline.
+    assert poll_mock.call_args.kwargs["baseline_status"] == KernelWorkerStatus.COMPLETE
+    assert poll_mock.call_args.args[0] == "testuser/my-kernel"
+    output_mock.assert_called_once()
+    assert output_mock.call_args.args[0] == "testuser/my-kernel"
+    assert output_mock.call_args.args[1] == "/tmp/out"
+    assert isinstance(result, KernelRunResult)
+    assert result.status == KernelWorkerStatus.COMPLETE
+    assert result.version_number == 7
+    assert result.ref == "testuser/my-kernel"
+    assert result.output_files == ["/tmp/out/sub.csv"]
+    assert result.elapsed_seconds is not None
+
+
+def test_run_without_output_path_skips_download():
+    api = _api()
+    with (
+        patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=("testuser", "my-kernel")),
+        patch.object(KaggleApi, "kernels_status", return_value=_status(KernelWorkerStatus.COMPLETE)),
+        patch.object(KaggleApi, "kernels_push", return_value=_push_response()),
+        patch.object(KaggleApi, "_poll_kernel_session", return_value=_status(KernelWorkerStatus.COMPLETE)),
+        patch.object(KaggleApi, "kernels_output") as output_mock,
+    ):
+        result = api.kernels_run("/tmp/folder", quiet=True)
+    output_mock.assert_not_called()
+    assert result.output_files == []
+
+
+def test_run_push_error_short_circuits():
+    api = _api()
+    with (
+        patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=("testuser", "my-kernel")),
+        patch.object(KaggleApi, "kernels_status", return_value=_status(KernelWorkerStatus.COMPLETE)),
+        patch.object(KaggleApi, "kernels_push", return_value=_push_response(error="bad metadata")),
+        patch.object(KaggleApi, "_poll_kernel_session") as poll_mock,
+    ):
+        with pytest.raises(ValueError, match="bad metadata"):
+            api.kernels_run("/tmp/folder", quiet=True)
+    poll_mock.assert_not_called()
+
+
+def test_run_baseline_read_failure_is_tolerated():
+    api = _api()
+    with (
+        patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=("testuser", "my-kernel")),
+        patch.object(KaggleApi, "kernels_status", side_effect=_http_error(404)),
+        patch.object(KaggleApi, "kernels_push", return_value=_push_response()),
+        patch.object(KaggleApi, "_poll_kernel_session", return_value=_status(KernelWorkerStatus.COMPLETE)) as poll_mock,
+    ):
+        api.kernels_run("/tmp/folder", quiet=True)
+    assert poll_mock.call_args.kwargs["baseline_status"] is None
+
+
+def test_run_resolves_ref_from_push_url_when_metadata_has_no_id():
+    api = _api()
+    push = _push_response(url="https://www.kaggle.com/code/owner2/slug2")
+    with (
+        patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=None),
+        patch.object(KaggleApi, "kernels_status") as status_mock,
+        patch.object(KaggleApi, "kernels_push", return_value=push),
+        patch.object(KaggleApi, "_poll_kernel_session", return_value=_status(KernelWorkerStatus.COMPLETE)) as poll_mock,
+    ):
+        result = api.kernels_run("/tmp/folder", quiet=True)
+    # No metadata id: no baseline read happens before the push.
+    status_mock.assert_not_called()
+    assert poll_mock.call_args.args[0] == "owner2/slug2"
+    assert result.ref == "owner2/slug2"
+
+
+def test_run_wait_timeout_defaults_to_twelve_hours():
+    api = _api()
+    for wait_timeout in (None, 0):
+        with (
+            patch.object(KaggleApi, "_kernel_ref_from_folder", return_value=("testuser", "my-kernel")),
+            patch.object(KaggleApi, "kernels_status", return_value=_status(KernelWorkerStatus.COMPLETE)),
+            patch.object(KaggleApi, "kernels_push", return_value=_push_response()),
+            patch.object(
+                KaggleApi, "_poll_kernel_session", return_value=_status(KernelWorkerStatus.COMPLETE)
+            ) as poll_mock,
+        ):
+            api.kernels_run("/tmp/folder", wait_timeout=wait_timeout, quiet=True)
+        assert poll_mock.call_args.args[1] == KaggleApi._DEFAULT_WAIT_TIMEOUT
+
+
+def test_run_file_pattern_requires_output():
+    with pytest.raises(ValueError, match="--file-pattern requires --output"):
+        _api().kernels_run("/tmp/folder", file_pattern="csv$")
+
+
+def test_run_force_requires_output():
+    with pytest.raises(ValueError, match="--force requires --output"):
+        _api().kernels_run("/tmp/folder", force=True)
+
+
+def test_run_poll_interval_minimum_enforced():
+    with pytest.raises(ValueError, match="--poll-interval must be at least"):
+        _api().kernels_run("/tmp/folder", poll_interval=1)
+
+
+def test_run_negative_wait_timeout_rejected():
+    with pytest.raises(ValueError, match="--wait-timeout cannot be negative"):
+        _api().kernels_run("/tmp/folder", wait_timeout=-1)
+
+
+# --------------------------------------------------------------------------
+# _kernel_ref_from_folder / _kernel_ref_from_push
+# --------------------------------------------------------------------------
+def _write_metadata(tmp_path, meta):
+    path = os.path.join(str(tmp_path), "kernel-metadata.json")
+    with open(path, "w") as f:
+        json.dump(meta, f)
+    return str(tmp_path)
+
+
+def test_kernel_ref_from_folder_reads_id(tmp_path):
+    folder = _write_metadata(tmp_path, {"id": "someuser/some-kernel"})
+    assert _api()._kernel_ref_from_folder(folder) == ("someuser", "some-kernel")
+
+
+def test_kernel_ref_from_folder_placeholder_returns_none(tmp_path):
+    folder = _write_metadata(tmp_path, {"id": "someuser/INSERT_KERNEL_SLUG_HERE"})
+    assert _api()._kernel_ref_from_folder(folder) is None
+
+
+def test_kernel_ref_from_folder_missing_id_returns_none(tmp_path):
+    folder = _write_metadata(tmp_path, {"id_no": 12345})
+    assert _api()._kernel_ref_from_folder(folder) is None
+
+
+def test_kernel_ref_from_push_falls_back_to_url(tmp_path):
+    folder = _write_metadata(tmp_path, {"id_no": 12345})
+    response = MagicMock()
+    response.url = "https://www.kaggle.com/code/owner3/slug3"
+    assert _api()._kernel_ref_from_push(folder, response) == ("owner3", "slug3")
+
+
+def test_kernel_ref_from_push_without_any_ref_raises(tmp_path):
+    folder = _write_metadata(tmp_path, {"id_no": 12345})
+    response = MagicMock()
+    response.url = ""
+    with pytest.raises(ValueError, match="owner/kernel-slug"):
+        _api()._kernel_ref_from_push(folder, response)
+
+
+# --------------------------------------------------------------------------
+# kernels_run_cli
+# --------------------------------------------------------------------------
+def test_run_cli_defaults_to_cwd_and_prints_output_hint(capsys):
+    api = _api()
+    result = KernelRunResult(status=KernelWorkerStatus.COMPLETE, version_number=7, url="u", ref="testuser/my-kernel")
+    with patch.object(KaggleApi, "kernels_run", return_value=result) as run_mock:
+        api.kernels_run_cli()
+    assert run_mock.call_args.args[0] == os.getcwd()
+    out = capsys.readouterr().out
+    assert "kaggle kernels output testuser/my-kernel" in out
+
+
+def test_run_cli_propagates_failure():
+    api = _api()
+    with patch.object(KaggleApi, "kernels_run", side_effect=ValueError("Kernel run failed")):
+        with pytest.raises(ValueError, match="Kernel run failed"):
+            api.kernels_run_cli(folder="/tmp/folder")


### PR DESCRIPTION
## Summary

This adds a new `kaggle kernels run` command that pushes a kernel to Kaggle and waits for the run to finish instead of returning immediately like `kernels push` does.

This is useful when using Kaggle notebooks as part of scripts or CI workflows, where manually running `kernels status` in a loop is not very convenient.

For example:

```bash
kaggle kernels run -p . --output ./results
```

The command waits for the kernel to complete, returns a non-zero exit code if the run fails, and can optionally download the output files.

## What changed

Added a new `kernels run` command with support for:

* Waiting for the kernel to finish with `--wait-timeout` and `--poll-interval`.
* Downloading outputs with `--output`.
* Filtering outputs with `--file-pattern`.
* Overwriting existing output files with `--force`.
* Proper exit codes for successful and failed runs.
* A stale-session check so an older completed session is not immediately treated as the new run.
* Useful recovery information when the wait is interrupted or times out.

The implementation reuses the existing polling/backoff and kernel output functionality instead of introducing a separate polling system.

## API limitation

While working on this, I also checked whether the run could be pinned to the exact kernel version returned by the push API.

The SDK exposes a `versionLabel` field, but testing it against the actual Kaggle API showed that it currently returns a `404` for real kernel versions. Because of this, the command uses the latest-session API with a pre-push baseline check rather than relying on `versionLabel`.

This also means that running multiple versions of the same kernel at the same time is not supported by this command for now.

## Tests

Added unit tests covering the kernel run state flow, including successful runs, failures, timeouts, transient API errors, stale sessions, validation, output handling, and CLI parsing.

Also added a backend test and manually verified the command against the live Kaggle API with both a successful and a failing kernel.

Ran:

`pytest tests/unit/test_kernels_run.py tests/unit/test_cli_kernels.py`

`pytest tests/unit`

`black --check` on the modified files

The full unit suite passes with 1319 tests passing.

The live validation also confirmed:

* Successful kernel → outputs downloaded → exit code `0`
* Failed kernel → error reported → exit code `1`