### PR TITLE
fix(cli): prevent HTTP errors from corrupting resumed downloads

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6285,8 +6285,8 @@ class KaggleApi:
                         size_read = 0
                         open_mode = "wb"
                         self._write_resume_marker(outfile, resume_validator, size)
-                    else:
-                        # e.g. 416 Range Not Satisfiable (local file >= remote size).
+                    elif response.status_code == 416:
+                        # Range Not Satisfiable (local file >= remote size).
                         # Discard the stale bytes and re-request the full object.
                         response.close()
                         response = requests.request(
@@ -6296,9 +6296,20 @@ class KaggleApi:
                             stream=True,
                             timeout=timeout,
                         )
+                        response.raise_for_status()
                         size_read = 0
                         open_mode = "wb"
                         self._write_resume_marker(outfile, resume_validator, size)
+                    else:
+                        # Any other status (e.g. 403 once the signed URL has expired,
+                        # or a 5xx) carries an error body rather than file content.
+                        # Raise instead of overwriting, so the partial file and its
+                        # resume marker survive for a later attempt.
+                        response.raise_for_status()
+                        raise requests.exceptions.HTTPError(
+                            f"Unexpected status code {response.status_code} when resuming download",
+                            response=response,
+                        )
                 else:
                     size_read = 0
                     open_mode = "wb"

--- a/tests/unit/test_download_resume.py
+++ b/tests/unit/test_download_resume.py
@@ -36,6 +36,7 @@ class _Origin:
         self.last_modified = last_modified
         self.range_requests = 0  # how many GETs carried a Range header
         self.if_range_seen = []  # If-Range values observed
+        self.deny_status = None  # when set, every GET fails with this status
 
 
 def _make_handler(origin):
@@ -50,6 +51,15 @@ def _make_handler(origin):
             self.send_header("Last-Modified", origin.last_modified)
 
         def do_GET(self):
+            if origin.deny_status is not None:
+                body = b"<?xml version='1.0' encoding='UTF-8'?><Error><Code>SignatureDoesNotMatch</Code></Error>"
+                self.send_response(origin.deny_status)
+                self.send_header("Content-Type", "application/xml; charset=UTF-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
             blob = origin.blob
             total = len(blob)
             rng = self.headers.get("Range")
@@ -129,6 +139,7 @@ class DownloadResumeTest(unittest.TestCase):
         # reset shared origin counters
         self.origin.range_requests = 0
         self.origin.if_range_seen = []
+        self.origin.deny_status = None
 
     @property
     def url(self):
@@ -216,6 +227,33 @@ class DownloadResumeTest(unittest.TestCase):
             result = f.read()
         self.assertEqual(result, b"C" * 150)  # overwritten, not "BBB...CCC"
         self.assertFalse(self._marker_exists())
+
+    def test_http_error_on_resume_preserves_partial(self):
+        """An HTTP error during the Range resume (e.g. 403 once the signed URL
+        has expired) must not overwrite the partial file with the error body,
+        and must leave resume state usable for a later attempt."""
+        blob = b"B" * 2000
+        self._set_remote(blob, etag='"v1"')
+        self._seed_file(blob[:600])
+        self._seed_marker('"v1"', 2000)
+
+        resp = requests.get(self.url, stream=True)  # valid initial response
+        self.origin.deny_status = 403  # signed URL expires before the resume
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.api.download_file(resp, self.outfile, http_client=None, quiet=True, resume=True, max_retries=0)
+
+        # The partial bytes survive untouched...
+        with open(self.outfile, "rb") as f:
+            self.assertEqual(f.read(), blob[:600])
+        # ...and the marker still describes the real object, not the error body.
+        self.assertTrue(self._marker_exists())
+        with open(self.api._resume_marker_path(self.outfile)) as f:
+            self.assertEqual(json.load(f), {"validator": '"v1"', "size": 2000})
+
+        # A later run against a working URL therefore resumes to correct content.
+        self.origin.deny_status = None
+        self.assertEqual(self._run(), blob)
 
     def test_fresh_download_writes_and_clears_marker(self):
         self._set_remote(b"B" * 120)


### PR DESCRIPTION
## Summary

While looking into the download resume flow, I found that an HTTP error during a `Range` request could end up overwriting the existing partial download.

The resume logic was treating any response other than `200` or `206` as the fallback case used for `416 Range Not Satisfiable`. So if the storage request returned something like `403` or `5xx`, the CLI would make another request without the `Range` header and then write that response to the file without checking its status.

This could replace a valid partial file with the error response. The resume marker was also left behind, so a later run could treat the error response as a valid partial download and append the remaining bytes. Since the final file size could still be correct, the existing size check would not catch the corruption.

This is particularly relevant for long-running downloads where a resume or storage error is more likely to occur.

## Fix

I restricted the full-download fallback to `416 Range Not Satisfiable` and added status checking for the fallback request.

For other HTTP errors such as `403`, `404`, or `5xx`, the error is now raised instead of modifying the existing partial file.

The existing `HTTPError` handling already retries the appropriate errors, so this keeps the change small and fits into the current download flow.

I also added a regression test to make sure a failed range-resume request does not overwrite the existing partial file or leave it in a corrupted state.

## Tests

Added a regression test covering a `403` response during a range-resume request.

Ran:

`pytest tests/unit/test_download_resume.py -q`

`pytest tests/unit -q`

`black --check .`

`mypy`

The regression test was also checked against the old implementation and failed before the fix, then passed with the fix.

All **1319 unit tests pass**.

`mypy` reports the same 7 pre-existing errors as before, with no new errors from the changed code.


I came across this while working with the RSNA Knee Abnormality Detection competition. The dataset is quite large and took a significant amount of time to download, which made me look more closely at how the Kaggle CLI handles interrupted and resumed downloads.

While going through that flow, I noticed this error-handling path and was able to reproduce the corruption locally.