### PR TITLE
fix(datasets): correct title to slug in dataset creation error message

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6029,7 +6029,7 @@ class KaggleApi:
         if found:
             resp = ApiCreateDatasetResponse()
             resp.status = "error"
-            resp.error = f'The requested title "{title}" is already in use by a dataset. Please choose another title.'
+            resp.error = f'The requested slug "{dataset_slug}" is already in use by a dataset. Please choose another slug.'
             return resp
 
         request = ApiCreateDatasetRequest()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6029,9 +6029,7 @@ class KaggleApi:
         if found:
             resp = ApiCreateDatasetResponse()
             resp.status = "error"
-            resp.error = (
-                f'The requested slug "{dataset_slug}" is already in use ' "by a dataset. Please choose another slug."
-            )
+            resp.error = f'The requested slug "{dataset_slug}" is already in use by a dataset. Please choose another slug.'
             return resp
 
         request = ApiCreateDatasetRequest()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6029,7 +6029,9 @@ class KaggleApi:
         if found:
             resp = ApiCreateDatasetResponse()
             resp.status = "error"
-            resp.error = f'The requested slug "{dataset_slug}" is already in use by a dataset. Please choose another slug.'
+            resp.error = (
+                f'The requested slug "{dataset_slug}" is already in use by a dataset. Please choose another slug.'
+            )
             return resp
 
         request = ApiCreateDatasetRequest()

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -6030,7 +6030,7 @@ class KaggleApi:
             resp = ApiCreateDatasetResponse()
             resp.status = "error"
             resp.error = (
-                f'The requested slug "{dataset_slug}" is already in use by a dataset. Please choose another slug.'
+                f'The requested slug "{dataset_slug}" is already in use ' "by a dataset. Please choose another slug."
             )
             return resp
 

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -163,14 +163,17 @@ class TestDatasetCreate(unittest.TestCase):
             self.assertIn("Subtitle length must be between 20 and 80 characters", str(context.exception))
 
     @patch.object(KaggleApi, "dataset_status")
-    def test_dataset_create_new_duplicate_title_fails(self, mock_status):
+    def test_dataset_create_new_duplicate_slug_fails(self, mock_status):
         mock_status.return_value = MagicMock()
         metadata = self._get_valid_metadata()
+        metadata["title"] = "Completely Unrelated Title"
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_metadata(tmpdir, metadata)
             response = self.api.dataset_create_new(tmpdir)
             self.assertEqual(response.status, "error")
-            self.assertIn("already in use by a dataset", response.error)
+            self.assertIn('already in use by a dataset', response.error)
+            self.assertIn('test-dataset', response.error)
+            self.assertNotIn("Completely Unrelated Title", response.error)
             mock_status.assert_called_once_with("testuser/test-dataset")
 
     @patch.object(KaggleApi, "dataset_status")

--- a/tests/unit/test_dataset_create.py
+++ b/tests/unit/test_dataset_create.py
@@ -171,8 +171,8 @@ class TestDatasetCreate(unittest.TestCase):
             self._write_metadata(tmpdir, metadata)
             response = self.api.dataset_create_new(tmpdir)
             self.assertEqual(response.status, "error")
-            self.assertIn('already in use by a dataset', response.error)
-            self.assertIn('test-dataset', response.error)
+            self.assertIn("already in use by a dataset", response.error)
+            self.assertIn("test-dataset", response.error)
             self.assertNotIn("Completely Unrelated Title", response.error)
             mock_status.assert_called_once_with("testuser/test-dataset")
 


### PR DESCRIPTION
## Why this PR:
This PR fixes a misleading error message that occurs during dataset creation when the requested slug is already in use by another entity (such as a notebook).

## Before this PR
Previously, if a user tried to create a dataset using an existing slug, the CLI incorrectly reported that the *title* was already in use. This PR updates the error message to correctly identify the *slug* as the cause of the conflict, making it easier for users to understand and resolve the issue.