### PR TITLE
fix(cli): keep the requested folder when downloading a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Keep the requested folder when downloading a single file with `kaggle datasets download -f` or `kaggle competitions download -f`, instead of writing it to the download root
 * Add `kaggle competitions host-add <comp> -u <user>` to grant host access on a competition to a Kaggle user
 * Suggest a next step on 403/404/429/5xx API errors, report unexpected errors as bugs instead of a traceback (with a new `--debug` flag), and list common examples in `kaggle --help`
 * Add `kaggle benchmarks quota` to show Model Proxy (AI inference) spend quota, and bump `kagglesdk` to `>= 0.1.37`

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -99,7 +99,7 @@ kaggle competitions download <COMPETITION> [options]
 
 **Options:**
 
-*   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified).
+*   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified). A file inside a folder, such as `train/labels.csv`, keeps that folder under the download path.
 *   `-p, --path <PATH>`: Folder to download files to (defaults to current directory).
 *   `-w, --wp`: Download files to the current working path (equivalent to `-p .`).
 *   `-o, --force`: Force download, overwriting existing files.
@@ -117,6 +117,12 @@ kaggle competitions download <COMPETITION> [options]
 
     ```bash
     kaggle competitions download titanic -f test.csv -p tost
+    ```
+
+3.  Download a file that lives in a folder inside the competition data. The file is written to `data/kaggle_evaluation/rsna_gateway.py`:
+
+    ```bash
+    kaggle competitions download rsna-intracranial-aneurysm-detection -f kaggle_evaluation/rsna_gateway.py -p data
     ```
 
 **Purpose:**

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -99,7 +99,7 @@ kaggle datasets download <DATASET> [options]
 
 **Options:**
 
-*   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified).
+*   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified). A file inside a folder, such as `train/labels.csv`, keeps that folder under the download path.
 *   `-p, --path <PATH>`: Folder to download files to (defaults to current directory).
 *   `-w, --wp`: Download files to the current working path.
 *   `--unzip`: Unzip the downloaded file (deletes the .zip file afterwards).
@@ -124,6 +124,12 @@ kaggle datasets download <DATASET> [options]
 
     ```bash
     kaggle datasets download goefft/public-datasets-with-file-types-and-columns -f dataset_results.csv -w -q -o
+    ```
+
+4.  Download a file that lives in a folder inside the dataset. The file is written to `data/WICAgencies2014ytd/Food_Costs.csv`:
+
+    ```bash
+    kaggle datasets download jpmiller/publicassistance -f WICAgencies2014ytd/Food_Costs.csv -p data
     ```
 
 **Purpose:**

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -116,7 +116,7 @@ kaggle competitions download [COMPETITION] [options]
 
 **Options:**
 
-- `-f, --file <NAME>`: Download one file. Downloads all files when omitted.
+- `-f, --file <NAME>`: Download one file. Downloads all files when omitted. A file inside a folder, such as `train/labels.csv`, keeps that folder under `--path`.
 - `-p, --path <PATH>`: Download directory.
 - `-w, --wp`: Download to current working path.
 - `-o, --force`: Force download even if local file looks current.
@@ -127,6 +127,7 @@ kaggle competitions download [COMPETITION] [options]
 ```bash
 kaggle competitions download titanic
 kaggle competitions download titanic -f train.csv -p data
+kaggle competitions download rsna-intracranial-aneurysm-detection -f kaggle_evaluation/rsna_gateway.py -p data
 kaggle c download -w -o -q
 ```
 

--- a/skills/references/datasets.md
+++ b/skills/references/datasets.md
@@ -105,7 +105,7 @@ kaggle datasets download [DATASET] [options]
 
 **Options:**
 
-- `-f, --file <NAME>`: Download one file. Downloads all files when omitted.
+- `-f, --file <NAME>`: Download one file. Downloads all files when omitted. A file inside a folder, such as `train/labels.csv`, keeps that folder under `--path`.
 - `-p, --path <PATH>`: Download directory.
 - `-w, --wp`: Download to current working path.
 - `--unzip`: Unzip the downloaded archive and delete the zip.
@@ -117,6 +117,7 @@ kaggle datasets download [DATASET] [options]
 ```bash
 kaggle datasets download kaggle/titanic
 kaggle d download kaggle/titanic -f train.csv -p data --unzip
+kaggle datasets download jpmiller/publicassistance -f WICAgencies2014ytd/Food_Costs.csv -p data
 ```
 
 **Purpose:** Retrieve dataset files for local work.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -539,11 +539,15 @@ def _resolve_download_path(destination: str, file_name: str, url: str) -> str:
     files are served compressed (a request for `foo.csv` arrives as `foo.csv.zip`) and
     only the URL records that.
 
+    Only the relative part is normalized, so an interior `..` cannot survive into the
+    result and leave a stray directory behind when the parent directories are created,
+    while `destination` stays exactly as the caller passed it.
+
     Raises ValueError if the resolved path would land outside `destination`.
     """
     base_name = url.split("?")[0].split("/")[-1]
     parts = [part for part in (file_name or "").replace("\\", "/").split("/") if part not in ("", ".")]
-    outfile = os.path.join(destination, *parts[:-1], base_name)
+    outfile = os.path.join(destination, os.path.normpath(os.path.join(*parts[:-1], base_name)))
     if not _is_within_directory(os.path.realpath(destination), os.path.realpath(outfile)):
         raise ValueError(f"Refusing to download '{file_name}': resolves outside destination '{destination}'")
     return outfile

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -530,6 +530,25 @@ def safe_extract_tar(t: tarfile.TarFile, path: str) -> None:
     t.extractall(base, members=safe_members)
 
 
+def _resolve_download_path(destination: str, file_name: str, url: str) -> str:
+    """Builds the local path for a single file download under `destination`.
+
+    The directory comes from the requested `file_name`, so a nested request keeps its
+    layout instead of collapsing into `destination` and colliding with same-named files
+    from other directories. The base name comes from the download URL, because large
+    files are served compressed (a request for `foo.csv` arrives as `foo.csv.zip`) and
+    only the URL records that.
+
+    Raises ValueError if the resolved path would land outside `destination`.
+    """
+    base_name = url.split("?")[0].split("/")[-1]
+    parts = [part for part in (file_name or "").replace("\\", "/").split("/") if part not in ("", ".")]
+    outfile = os.path.join(destination, *parts[:-1], base_name)
+    if not _is_within_directory(os.path.realpath(destination), os.path.realpath(outfile)):
+        raise ValueError(f"Refusing to download '{file_name}': resolves outside destination '{destination}'")
+    return outfile
+
+
 def should_ignore(rel_path: str, is_dir: bool, patterns: List[str]) -> bool:
     """Helper to check if a path should be ignored based on patterns."""
     import fnmatch
@@ -2626,7 +2645,7 @@ class KaggleApi:
             request.file_name = file_name
             response = kaggle.competitions.competition_api_client.download_data_file(request)
         url = response.request.url
-        outfile = cast(str, os.path.join(effective_path, url.split("?")[0].split("/")[-1]))
+        outfile = _resolve_download_path(effective_path, file_name, url)
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
@@ -5524,7 +5543,7 @@ class KaggleApi:
             request.file_name = file_name
             response = kaggle.datasets.dataset_api_client.download_dataset(request)
         url = response.request.url
-        outfile = os.path.join(effective_path, url.split("?")[0].split("/")[-1])
+        outfile = _resolve_download_path(effective_path, file_name, url)
 
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)

--- a/tests/unit/test_download_file_paths.py
+++ b/tests/unit/test_download_file_paths.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../../src")
+
+from kaggle.api.kaggle_api_extended import KaggleApi, _resolve_download_path
+
+
+def _signed_url(base_name):
+    """Builds a URL shaped like the signed storage URLs the API redirects downloads to."""
+    return f"https://storage.googleapis.com/kagglesdsdata/datasets/1/2/{base_name}?GoogleAccessId=x&Signature=y"
+
+
+class TestResolveDownloadPath(unittest.TestCase):
+    """Tests for _resolve_download_path, which decides where a single file download lands."""
+
+    def _resolve(self, file_name, base_name=None):
+        url = _signed_url(base_name if base_name is not None else file_name.split("/")[-1])
+        return os.path.normpath(_resolve_download_path("dest", file_name, url))
+
+    def test_flat_file_lands_directly_in_destination(self):
+        self.assertEqual(self._resolve("train.csv"), os.path.normpath("dest/train.csv"))
+
+    def test_nested_file_keeps_its_directory(self):
+        self.assertEqual(
+            self._resolve("WICAgencies2014ytd/Food_Costs.csv"),
+            os.path.normpath("dest/WICAgencies2014ytd/Food_Costs.csv"),
+        )
+
+    def test_deeply_nested_file_keeps_every_level(self):
+        self.assertEqual(
+            self._resolve("kaggle_evaluation/core/generated/__init__.py"),
+            os.path.normpath("dest/kaggle_evaluation/core/generated/__init__.py"),
+        )
+
+    def test_same_base_name_in_different_directories_resolves_to_different_paths(self):
+        first = self._resolve("WICAgencies2013ytd/Food_Costs.csv")
+        second = self._resolve("WICAgencies2014ytd/Food_Costs.csv")
+        self.assertNotEqual(first, second)
+
+    def test_flat_compressed_response_keeps_the_zip_suffix(self):
+        self.assertEqual(
+            self._resolve("creditcard.csv", base_name="creditcard.csv.zip"),
+            os.path.normpath("dest/creditcard.csv.zip"),
+        )
+
+    def test_nested_compressed_response_keeps_directory_and_zip_suffix(self):
+        self.assertEqual(
+            self._resolve("cord_19_embeddings/embeddings.csv", base_name="embeddings.csv.zip"),
+            os.path.normpath("dest/cord_19_embeddings/embeddings.csv.zip"),
+        )
+
+    def test_backslash_separators_are_normalized(self):
+        self.assertEqual(
+            self._resolve("train\\labels\\y.csv", base_name="y.csv"),
+            os.path.normpath("dest/train/labels/y.csv"),
+        )
+
+    def test_redundant_separators_and_dot_segments_are_dropped(self):
+        self.assertEqual(self._resolve("./train//y.csv", base_name="y.csv"), os.path.normpath("dest/train/y.csv"))
+
+    def test_leading_separator_stays_inside_the_destination(self):
+        self.assertEqual(self._resolve("/train/y.csv", base_name="y.csv"), os.path.normpath("dest/train/y.csv"))
+
+    def test_rejects_parent_traversal(self):
+        with self.assertRaises(ValueError):
+            _resolve_download_path("dest", "../evil.csv", _signed_url("evil.csv"))
+
+    def test_rejects_traversal_hidden_mid_path(self):
+        with self.assertRaises(ValueError):
+            _resolve_download_path("dest", "train/../../../evil.csv", _signed_url("evil.csv"))
+
+    def test_rejects_backslash_traversal(self):
+        with self.assertRaises(ValueError):
+            _resolve_download_path("dest", "..\\..\\evil.csv", _signed_url("evil.csv"))
+
+
+class TestDownloadFileDestinations(unittest.TestCase):
+    """Tests that both single file download methods write to the requested path."""
+
+    DESTINATION = os.path.normpath("/tmp/download")
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+
+    @staticmethod
+    def _mock_client(mock_client, base_name):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = _signed_url(base_name)
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_kaggle.competitions.competition_api_client.download_data_file.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_writes_nested_path(self, mock_client, mock_download_file, mock_download_needed):
+        self._mock_client(mock_client, "Food_Costs.csv")
+
+        self.api.dataset_download_file("owner/my-dataset", "WICAgencies2014ytd/Food_Costs.csv", path=self.DESTINATION)
+
+        expected = os.path.join(self.DESTINATION, "WICAgencies2014ytd", "Food_Costs.csv")
+        self.assertEqual(mock_download_file.call_args[0][1], expected)
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_dataset_download_file_flat_path_is_unchanged(self, mock_client, mock_download_file, mock_download_needed):
+        self._mock_client(mock_client, "train.csv")
+
+        self.api.dataset_download_file("owner/my-dataset", "train.csv", path=self.DESTINATION)
+
+        self.assertEqual(mock_download_file.call_args[0][1], os.path.join(self.DESTINATION, "train.csv"))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_competition_download_file_writes_nested_path(self, mock_client, mock_download_file, mock_download_needed):
+        self._mock_client(mock_client, "rsna_gateway.py")
+
+        self.api.competition_download_file(
+            "some-competition", "kaggle_evaluation/rsna_gateway.py", path=self.DESTINATION
+        )
+
+        expected = os.path.join(self.DESTINATION, "kaggle_evaluation", "rsna_gateway.py")
+        self.assertEqual(mock_download_file.call_args[0][1], expected)
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_competition_download_file_flat_path_is_unchanged(
+        self, mock_client, mock_download_file, mock_download_needed
+    ):
+        self._mock_client(mock_client, "train.csv")
+
+        self.api.competition_download_file("some-competition", "train.csv", path=self.DESTINATION)
+
+        self.assertEqual(mock_download_file.call_args[0][1], os.path.join(self.DESTINATION, "train.csv"))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_competition_download_file_rejects_traversal(self, mock_client, mock_download_file, mock_download_needed):
+        self._mock_client(mock_client, "evil.csv")
+
+        with self.assertRaises(ValueError):
+            self.api.competition_download_file("some-competition", "../evil.csv", path=self.DESTINATION)
+
+        mock_download_file.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_download_file_paths.py
+++ b/tests/unit/test_download_file_paths.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -64,6 +66,30 @@ class TestResolveDownloadPath(unittest.TestCase):
 
     def test_leading_separator_stays_inside_the_destination(self):
         self.assertEqual(self._resolve("/train/y.csv", base_name="y.csv"), os.path.normpath("dest/train/y.csv"))
+
+    def test_interior_parent_segment_is_collapsed(self):
+        # Asserted on the raw return value: normalizing it here would hide the bug.
+        outfile = _resolve_download_path("dest", "foo/../bar/y.csv", _signed_url("y.csv"))
+        self.assertEqual(outfile, os.path.join("dest", "bar", "y.csv"))
+
+    def test_creating_parent_directories_leaves_no_stray_directory(self):
+        # download_file() creates the parent directories, and an unnormalized "foo/.."
+        # makes it create an empty "foo" when the destination does not already exist.
+        root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, root, True)
+        destination = os.path.join(root, "new-download-dir")
+
+        outfile = _resolve_download_path(destination, "foo/../bar/y.csv", _signed_url("y.csv"))
+        parent = os.path.dirname(outfile)
+        if not os.path.exists(parent):
+            os.makedirs(parent)
+
+        self.assertEqual(sorted(os.listdir(destination)), ["bar"])
+
+    def test_destination_is_left_exactly_as_passed(self):
+        # Normalizing the whole path would rewrite the caller's own -p value.
+        outfile = _resolve_download_path("/tmp/download", "a/b/y.csv", _signed_url("y.csv"))
+        self.assertEqual(outfile, os.path.join("/tmp/download", "a", "b", "y.csv"))
 
     def test_rejects_parent_traversal(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

`kaggle datasets download -f <path>` and `kaggle competitions download -f <path>` named the output file from the last segment of the signed storage URL and ignored the requested path, so a file inside a folder was written to the destination root. Two files sharing a base name resolved to the same local path, and one request would leave the other file's contents on disk while exiting 0.

## Problem

`jpmiller/publicassistance` is public and about 300 KB. It has four folders that each contain a `Food_Costs.csv`.

```bash
kaggle datasets download jpmiller/publicassistance -f WICAgencies2013ytd/Food_Costs.csv -p out
kaggle datasets download jpmiller/publicassistance -f WICAgencies2014ytd/Food_Costs.csv -p out
```

Before this change, both commands wrote to `out/Food_Costs.csv`. The second request was skipped because a file of that name already existed, so it exited 0 and left the 2013 file in place:

```text
WICAgencies2013ytd/Food_Costs.csv   12695 bytes   sha256 9933552f3403d281...
WICAgencies2014ytd/Food_Costs.csv   12681 bytes   sha256 3cd6049ae8de4336...
out/Food_Costs.csv                  12695 bytes   sha256 9933552f3403d281...
```

Downloading the whole dataset with `--unzip` reproduces the folders, and `kernels output` already writes to `os.path.join(target_dir, item.file_name)`. Only the single file download path flattened.

## Solution

`_resolve_download_path()` takes the directory from the requested `file_name` and the base name from the download URL, then checks the result with the existing `_is_within_directory()`.

The base name has to keep coming from the URL because large files are served compressed. `creditcard.csv` arrives as `creditcard.csv.zip`, and only the URL records that. Using the whole requested path would write a zip archive named `.csv`.

A `file_name` with no directory part resolves exactly as before, so flat downloads and the compressed base name behavior are unchanged.

Both call sites now resolve through the same helper. `download_file()` already creates the parent directory, so nothing else was needed there.

After this change:

```text
out/WICAgencies2013ytd/Food_Costs.csv   12695 bytes   sha256 9933552f3403d281...
out/WICAgencies2014ytd/Food_Costs.csv   12681 bytes   sha256 3cd6049ae8de4336...
```

## Behavior change

A nested `-f` download now lands under the requested folder instead of the destination root. This is a change for anyone relying on the file arriving at the root. I have made it unconditional rather than gating it behind a flag, since the current placement can leave a different file than the one requested, but I am happy to gate it if you would rather keep the existing layout as the default.

## Testing

- [x] `hatch -e test run pytest tests/unit/test_download_file_paths.py -v` (17 passed)
- [x] `hatch -e test run pytest tests/unit` (1303 passed, 3 skipped)
- [x] `hatch run lint:all`
- [x] Verified against the live API: the two `Food_Costs.csv` files now land side by side with the hashes above, `creditcard.csv` still arrives as `creditcard.csv.zip`, a flat file is unchanged, and `competitions download -f kaggle_evaluation/core/__init__.py` writes the nested path
- [ ] Maintainer: please run `/gcbrun` when convenient

New tests cover a flat path, a nested path, deep nesting, two files sharing a base name, a compressed response with and without a folder, backslash separators, dot and repeated separators, a leading separator, and three traversal inputs. The three behavior tests fail against the previous code.

Docs updated in `docs/datasets.md`, `docs/competitions.md`, `skills/references/datasets.md`, and `skills/references/competitions.md`.

## Related

Fixes #1178
