### PR TITLE
Fix misleading code competition submission validation errors

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2084,22 +2084,25 @@ class KaggleApi:
 
         if kernel is None:
             raise ValueError("No kernel specified")
-        else:
-            with self.build_kaggle_client() as kaggle:
-                items = kernel.split("/")
-                if len(items) != 2:
-                    raise ValueError("The kernel must be specified as <owner>/<notebook>")
-                submit_request = ApiCreateCodeSubmissionRequest()
-                submit_request.file_name = file_name
-                submit_request.competition_name = competition
-                submit_request._kernel_owner = items[0]
-                submit_request.kernel_slug = items[1]
-                if kernel_version:
-                    submit_request.kernel_version = int(kernel_version)
-                if message:
-                    submit_request.submission_description = message
-                submit_response = kaggle.competitions.competition_api_client.create_code_submission(submit_request)
-                return submit_response
+
+        if file_name is None:
+            raise ValueError("No file specified")
+
+        with self.build_kaggle_client() as kaggle:
+            items = kernel.split("/")
+            if len(items) != 2:
+                raise ValueError("The kernel must be specified as <owner>/<notebook>")
+            submit_request = ApiCreateCodeSubmissionRequest()
+            submit_request.file_name = file_name
+            submit_request.competition_name = competition
+            submit_request._kernel_owner = items[0]
+            submit_request.kernel_slug = items[1]
+            if kernel_version:
+                submit_request.kernel_version = int(kernel_version)
+            if message:
+                submit_request.submission_description = message
+            submit_response = kaggle.competitions.competition_api_client.create_code_submission(submit_request)
+            return submit_response
 
     def competition_submit(
         self,
@@ -2197,11 +2200,7 @@ class KaggleApi:
             str:
         """
         if kernel and not version or version and not kernel:
-            raise ValueError(
-                "Code competition submissions require both the kernel name and the version number"
-            )
-        if kernel and not file_name:
-            raise ValueError("No file specified")
+            raise ValueError("Code competition submissions require both the kernel name and the version number")
         if wait is not None:
             if poll_interval < self._MIN_POLL_INTERVAL:
                 raise ValueError(

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -2197,7 +2197,11 @@ class KaggleApi:
             str:
         """
         if kernel and not version or version and not kernel:
-            raise ValueError("Code competition submissions require both the output file name and the version number")
+            raise ValueError(
+                "Code competition submissions require both the kernel name and the version number"
+            )
+        if kernel and not file_name:
+            raise ValueError("No file specified")
         if wait is not None:
             if poll_interval < self._MIN_POLL_INTERVAL:
                 raise ValueError(

--- a/tests/unit/test_competition_submit.py
+++ b/tests/unit/test_competition_submit.py
@@ -223,6 +223,51 @@ class TestCompetitionSubmit(unittest.TestCase):
         self.assertIn("Using competition: config-comp", f.getvalue())
 
 
+class TestCompetitionSubmitCli(unittest.TestCase):
+    """Tests for competition_submit_cli argument validation."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.already_printed_version_warning = True
+
+    def test_cli_code_submission_requires_kernel_and_version_together(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.competition_submit_cli(
+                file_name="output.csv",
+                message="message",
+                competition="comp-name",
+                version="1",
+            )
+        self.assertIn(
+            "Code competition submissions require both the kernel name and the version number",
+            str(context.exception),
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self.api.competition_submit_cli(
+                file_name="output.csv",
+                message="message",
+                competition="comp-name",
+                kernel="owner/notebook",
+            )
+        self.assertIn(
+            "Code competition submissions require both the kernel name and the version number",
+            str(context.exception),
+        )
+
+    def test_cli_code_submission_requires_file(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.competition_submit_cli(
+                file_name=None,
+                message="message",
+                competition="comp-name",
+                kernel="owner/notebook",
+                version="1",
+            )
+        self.assertIn("No file specified", str(context.exception))
+
+
 class TestCompetitionSubmitCliLimits(unittest.TestCase):
     """After a successful submit, the CLI wrapper should print the remaining
     submission allowance for the day. Limits errors must not fail the submit."""

--- a/tests/unit/test_competition_submit.py
+++ b/tests/unit/test_competition_submit.py
@@ -222,6 +222,18 @@ class TestCompetitionSubmit(unittest.TestCase):
 
         self.assertIn("Using competition: config-comp", f.getvalue())
 
+    def test_competition_submit_code_requires_file(self):
+        with self.assertRaises(ValueError) as context:
+            self.api.competition_submit_code(
+                None,
+                "message",
+                "comp",
+                "owner/notebook",
+                1,
+            )
+
+        self.assertIn("No file specified", str(context.exception))
+
 
 class TestCompetitionSubmitCli(unittest.TestCase):
     """Tests for competition_submit_cli argument validation."""


### PR DESCRIPTION
## Summary

Fixes #1182 

- Correct the misleading error message when `--kernel` and `--version` are not provided together.
- Validate that an output file is provided for code competition submissions before making the API request.
- Add regression tests covering both validation cases.

## Testing

- `pytest tests/unit/test_competition_submit.py` — 18 passed
- `pytest` — 1291 passed, 1 warnings
- `git diff --check` — passed

The existing code competition submission path with `--kernel`, `--version`, and `--file` remains unchanged.