### PR TITLE
fix(cli): honor --unzip for single file downloads and add it to competitions download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Honor `--unzip` when downloading a single file with `kaggle datasets download -f`, which extracts the file from the zip archive the server wraps large files in, and add `--unzip` to `kaggle competitions download`
 * Keep the requested folder when downloading a single file with `kaggle datasets download -f` or `kaggle competitions download -f`, instead of writing it to the download root
 * Add `kaggle competitions host-add <comp> -u <user>` to grant host access on a competition to a Kaggle user
 * Suggest a next step on 403/404/429/5xx API errors, report unexpected errors as bugs instead of a traceback (with a new `--debug` flag), and list common examples in `kaggle --help`

--- a/docs/competitions.md
+++ b/docs/competitions.md
@@ -102,6 +102,7 @@ kaggle competitions download <COMPETITION> [options]
 *   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified). A file inside a folder, such as `train/labels.csv`, keeps that folder under the download path.
 *   `-p, --path <PATH>`: Folder to download files to (defaults to current directory).
 *   `-w, --wp`: Download files to the current working path (equivalent to `-p .`).
+*   `--unzip`: Unzip the downloaded file (deletes the .zip file afterwards).
 *   `-o, --force`: Force download, overwriting existing files.
 *   `-q, --quiet`: Suppress verbose output.
 
@@ -123,6 +124,12 @@ kaggle competitions download <COMPETITION> [options]
 
     ```bash
     kaggle competitions download rsna-intracranial-aneurysm-detection -f kaggle_evaluation/rsna_gateway.py -p data
+    ```
+
+4.  Download all files for the "titanic" competition into `data` and extract them, leaving no zip behind:
+
+    ```bash
+    kaggle competitions download titanic -p data --unzip
     ```
 
 **Purpose:**

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -102,7 +102,7 @@ kaggle datasets download <DATASET> [options]
 *   `-f, --file <FILE_NAME>`: Specific file to download (downloads all if not specified). A file inside a folder, such as `train/labels.csv`, keeps that folder under the download path.
 *   `-p, --path <PATH>`: Folder to download files to (defaults to current directory).
 *   `-w, --wp`: Download files to the current working path.
-*   `--unzip`: Unzip the downloaded file (deletes the .zip file afterwards).
+*   `--unzip`: Unzip the downloaded file (deletes the .zip file afterwards). With `-f`, large files are served inside a zip archive of the same name, and this extracts the file from it.
 *   `-o, --force`: Force download, overwriting existing files.
 *   `-q, --quiet`: Suppress verbose output.
 
@@ -130,6 +130,12 @@ kaggle datasets download <DATASET> [options]
 
     ```bash
     kaggle datasets download jpmiller/publicassistance -f WICAgencies2014ytd/Food_Costs.csv -p data
+    ```
+
+5.  Download a single large file and extract it. `creditcard.csv` is served as `creditcard.csv.zip`, so without `--unzip` the archive is what lands on disk:
+
+    ```bash
+    kaggle datasets download mlg-ulb/creditcardfraud -f creditcard.csv -p data --unzip
     ```
 
 **Purpose:**

--- a/skills/references/competitions.md
+++ b/skills/references/competitions.md
@@ -119,6 +119,7 @@ kaggle competitions download [COMPETITION] [options]
 - `-f, --file <NAME>`: Download one file. Downloads all files when omitted. A file inside a folder, such as `train/labels.csv`, keeps that folder under `--path`.
 - `-p, --path <PATH>`: Download directory.
 - `-w, --wp`: Download to current working path.
+- `--unzip`: Unzip the downloaded archive and delete the zip.
 - `-o, --force`: Force download even if local file looks current.
 - `-q, --quiet`: Suppress progress output.
 
@@ -126,6 +127,7 @@ kaggle competitions download [COMPETITION] [options]
 
 ```bash
 kaggle competitions download titanic
+kaggle competitions download titanic -p data --unzip
 kaggle competitions download titanic -f train.csv -p data
 kaggle competitions download rsna-intracranial-aneurysm-detection -f kaggle_evaluation/rsna_gateway.py -p data
 kaggle c download -w -o -q

--- a/skills/references/datasets.md
+++ b/skills/references/datasets.md
@@ -108,7 +108,7 @@ kaggle datasets download [DATASET] [options]
 - `-f, --file <NAME>`: Download one file. Downloads all files when omitted. A file inside a folder, such as `train/labels.csv`, keeps that folder under `--path`.
 - `-p, --path <PATH>`: Download directory.
 - `-w, --wp`: Download to current working path.
-- `--unzip`: Unzip the downloaded archive and delete the zip.
+- `--unzip`: Unzip the downloaded archive and delete the zip. With `-f`, extracts the file from the zip archive the server wraps large files in.
 - `-o, --force`: Force download even if local file looks current.
 - `-q, --quiet`: Suppress progress output.
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -1024,15 +1024,26 @@ def format_http_error(error: HTTPError) -> str:
     return f"{message}\n\n{hint}" if hint else message
 
 
-def _extract_and_remove_zip(archive: str, destination: str) -> None:
+def _extract_and_remove_zip(archive: str, destination: str, unwrap_to: Optional[str] = None) -> None:
     """Extracts `archive` into `destination` and then deletes the archive.
 
-    zipfile.extractall() drops '..' segments and absolute prefixes from member names,
-    so extraction cannot escape `destination`.
+    `unwrap_to` is the path a server side single file wrapper should produce. The one
+    member is written there rather than to the name recorded inside the archive, so the
+    result does not depend on whether the server stores the file under its base name or
+    under the path that was requested. An archive holding any other number of members is
+    treated as a bundle.
+
+    Bundles go through zipfile.extractall(), which drops '..' segments and absolute
+    prefixes from member names, so extraction cannot escape `destination`.
     """
     try:
         with zipfile.ZipFile(archive) as z:
-            z.extractall(destination)
+            members = z.namelist()
+            if unwrap_to is not None and len(members) == 1:
+                with z.open(members[0]) as source, open(unwrap_to, "wb") as target:
+                    shutil.copyfileobj(source, target)
+            else:
+                z.extractall(destination)
     except zipfile.BadZipFile:
         raise ValueError(
             f"The file {archive} is corrupted or not a valid zip file. "
@@ -2702,7 +2713,7 @@ class KaggleApi:
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
 
         if unzip and _is_auto_compressed(outfile, file_name):
-            _extract_and_remove_zip(outfile, os.path.dirname(outfile))
+            _extract_and_remove_zip(outfile, os.path.dirname(outfile), unwrap_to=outfile[: -len(".zip")])
 
     def competition_download_files(
         self,
@@ -5618,7 +5629,7 @@ class KaggleApi:
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
 
         if unzip and _is_auto_compressed(outfile, file_name):
-            _extract_and_remove_zip(outfile, os.path.dirname(outfile))
+            _extract_and_remove_zip(outfile, os.path.dirname(outfile), unwrap_to=outfile[: -len(".zip")])
 
         return downloaded
 

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -553,6 +553,17 @@ def _resolve_download_path(destination: str, file_name: str, url: str) -> str:
     return outfile
 
 
+def _is_auto_compressed(outfile: str, file_name: str) -> bool:
+    """True when the server wrapped the requested file in a zip archive of the same name.
+
+    Large files are served compressed, so a request for `foo.csv` arrives as `foo.csv.zip`.
+    Requiring the exact `<requested>.zip` name leaves a file that is genuinely a `.zip`
+    inside the dataset alone, since its download is not renamed.
+    """
+    requested = os.path.basename((file_name or "").replace("\\", "/").rstrip("/"))
+    return bool(requested) and os.path.basename(outfile) == requested + ".zip"
+
+
 def should_ignore(rel_path: str, is_dir: bool, patterns: List[str]) -> bool:
     """Helper to check if a path should be ignored based on patterns."""
     import fnmatch
@@ -1011,6 +1022,31 @@ def format_http_error(error: HTTPError) -> str:
     if response is not None and response.status_code >= 500:
         hint = "This is a problem on Kaggle's side, not with your command. Please try again later."
     return f"{message}\n\n{hint}" if hint else message
+
+
+def _extract_and_remove_zip(archive: str, destination: str) -> None:
+    """Extracts `archive` into `destination` and then deletes the archive.
+
+    zipfile.extractall() drops '..' segments and absolute prefixes from member names,
+    so extraction cannot escape `destination`.
+    """
+    try:
+        with zipfile.ZipFile(archive) as z:
+            z.extractall(destination)
+    except zipfile.BadZipFile:
+        raise ValueError(
+            f"The file {archive} is corrupted or not a valid zip file. "
+            f"Please report this issue at {ISSUE_TRACKER_URL}"
+        )
+    except FileNotFoundError:
+        raise FileNotFoundError(f"The file {archive} was not found. Please report this issue at {ISSUE_TRACKER_URL}")
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred: {e}. Please report this issue at {ISSUE_TRACKER_URL}")
+
+    try:
+        os.remove(archive)
+    except OSError as e:
+        print("Could not delete zip file, got %s" % e)
 
 
 def print_auth_help() -> None:
@@ -2627,7 +2663,13 @@ class KaggleApi:
                 print("No files found")
 
     def competition_download_file(
-        self, competition: str, file_name: str, path: Optional[str] = None, force: bool = False, quiet: bool = False
+        self,
+        competition: str,
+        file_name: str,
+        path: Optional[str] = None,
+        force: bool = False,
+        quiet: bool = False,
+        unzip: bool = False,
     ) -> None:
         """Downloads a competition file.
 
@@ -2637,6 +2679,8 @@ class KaggleApi:
             path (Optional[str]): A path to download the file to.
             force (bool): Force the download if the file already exists (default False).
             quiet (bool): Suppress verbose output (default is False).
+            unzip (bool): If True, extract the file from the zip archive the server wraps
+                large files in, and delete the archive (default is False).
 
         Returns:
             None:
@@ -2657,8 +2701,16 @@ class KaggleApi:
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
 
+        if unzip and _is_auto_compressed(outfile, file_name):
+            _extract_and_remove_zip(outfile, os.path.dirname(outfile))
+
     def competition_download_files(
-        self, competition: str, path: Optional[str] = None, force: bool = False, quiet: bool = True
+        self,
+        competition: str,
+        path: Optional[str] = None,
+        force: bool = False,
+        quiet: bool = True,
+        unzip: bool = False,
     ) -> None:
         """Downloads all competition files.
 
@@ -2667,6 +2719,9 @@ class KaggleApi:
             path (Optional[str]): A path to download the file to.
             force (bool): Force the download if the file already exists (default False).
             quiet (bool): Suppress verbose output (default is True).
+            unzip (bool): If True, extract the downloaded archive and delete it. Competition
+                data is served as a zip; a bundle served in any other format is left as is
+                (default is False).
 
         Returns:
             None:
@@ -2686,8 +2741,11 @@ class KaggleApi:
             if force or self.download_needed(response, outfile, quiet):
                 self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
 
+        if unzip and outfile.endswith(".zip"):
+            _extract_and_remove_zip(outfile, effective_path)
+
     def competition_download_cli(
-        self, competition, competition_opt=None, file_name=None, path=None, force=False, quiet=False
+        self, competition, competition_opt=None, file_name=None, path=None, force=False, quiet=False, unzip=False
     ):
         """Downloads competition files.
 
@@ -2698,6 +2756,7 @@ class KaggleApi:
             path: A path to download the file to.
             force: Force the download if the file already exists (default False).
             quiet: Suppress verbose output (default is False).
+            unzip: Extract the downloaded archive and delete it (default is False).
         """
         competition = competition or competition_opt
         if competition is None:
@@ -2709,9 +2768,9 @@ class KaggleApi:
             raise ValueError("No competition specified")
         else:
             if file_name is None:
-                self.competition_download_files(competition, path, force, quiet)
+                self.competition_download_files(competition, path, force, quiet, unzip)
             else:
-                self.competition_download_file(competition, file_name, path, force, quiet)
+                self.competition_download_file(competition, file_name, path, force, quiet, unzip)
 
     def competition_leaderboard_download(self, competition: str, path: str, quiet: bool = True) -> None:
         """Downloads a competition leaderboard.
@@ -5516,7 +5575,7 @@ class KaggleApi:
         dataset = dataset or dataset_opt
         return self.dataset_status(dataset, format=format)
 
-    def dataset_download_file(self, dataset, file_name, path=None, force=False, quiet=True, licenses=[]):
+    def dataset_download_file(self, dataset, file_name, path=None, force=False, quiet=True, licenses=[], unzip=False):
         """Download a single file for a dataset.
 
         Args:
@@ -5526,6 +5585,8 @@ class KaggleApi:
             force: force the download if the file already exists (default False)
             quiet: suppress verbose output (default is True)
             licenses: a list of license names, e.g. ['CC0-1.0']
+            unzip: if True, extract the file from the zip archive the server wraps large
+                files in, and delete the archive (default is False)
         """
         if "/" in dataset:
             self.validate_dataset_string(dataset)
@@ -5552,11 +5613,14 @@ class KaggleApi:
         url = response.request.url
         outfile = _resolve_download_path(effective_path, file_name, url)
 
-        if force or self.download_needed(response, outfile, quiet):
+        downloaded = force or self.download_needed(response, outfile, quiet)
+        if downloaded:
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
-            return True
-        else:
-            return False
+
+        if unzip and _is_auto_compressed(outfile, file_name):
+            _extract_and_remove_zip(outfile, os.path.dirname(outfile))
+
+        return downloaded
 
     def dataset_download_files(self, dataset, path=None, force=False, quiet=True, unzip=False, licenses=[]):
         """Downloads all files for a dataset.
@@ -5589,36 +5653,9 @@ class KaggleApi:
         outfile = os.path.join(effective_path, dataset_slug + ".zip")
         if force or self.download_needed(response, outfile, quiet):
             self.download_file(response, outfile, kaggle.http_client(), quiet, not force)
-            downloaded = True
-        else:
-            downloaded = False
 
-        if downloaded or unzip:
-            outfile = os.path.join(effective_path, dataset_slug + ".zip")
-            if unzip:
-                try:
-                    with zipfile.ZipFile(outfile) as z:
-                        z.extractall(effective_path)
-                except zipfile.BadZipFile as e:
-                    raise ValueError(
-                        f"The file {outfile} is corrupted or not a valid zip file. "
-                        "Please report this issue at https://www.github.com/kaggle/kaggle-cli/issues"
-                    )
-                except FileNotFoundError:
-                    raise FileNotFoundError(
-                        f"The file {outfile} was not found. "
-                        "Please report this issue at https://www.github.com/kaggle/kaggle-cli"
-                    )
-                except Exception as e:
-                    raise RuntimeError(
-                        f"An unexpected error occurred: {e}. "
-                        "Please report this issue at https://www.github.com/kaggle/kaggle-cli"
-                    )
-
-                try:
-                    os.remove(outfile)
-                except OSError as e:
-                    print("Could not delete zip file, got %s" % e)
+        if unzip:
+            _extract_and_remove_zip(outfile, effective_path)
 
     def _print_dataset_url_and_license(self, owner_slug, dataset_slug, dataset_version_number, licenses):
         if dataset_version_number is None:
@@ -5671,7 +5708,9 @@ class KaggleApi:
         if file_name is None:
             self.dataset_download_files(dataset, path=path, unzip=unzip, force=force, quiet=quiet, licenses=licenses)
         else:
-            self.dataset_download_file(dataset, file_name, path=path, force=force, quiet=quiet, licenses=licenses)
+            self.dataset_download_file(
+                dataset, file_name, path=path, force=force, quiet=quiet, licenses=licenses, unzip=unzip
+            )
 
     def _upload_blob(
         self,

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -245,6 +245,9 @@ def parse_competitions(subparsers) -> None:
         "-w", "--wp", dest="path", action="store_const", const=".", required=False, help=Help.param_wp
     )
     parser_competitions_download_optional.add_argument(
+        "--unzip", dest="unzip", action="store_true", help=Help.param_unzip
+    )
+    parser_competitions_download_optional.add_argument(
         "-o", "--force", dest="force", action="store_true", help=Help.param_force
     )
     parser_competitions_download_optional.add_argument(

--- a/tests/unit/test_cli_competitions.py
+++ b/tests/unit/test_cli_competitions.py
@@ -95,6 +95,7 @@ def test_competitions_download_parser_default_succeeds(parser):
     assert kwargs.get("competition") is None
     assert kwargs.get("file_name") is None
     assert kwargs.get("path") is None
+    assert kwargs.get("unzip") is False
     assert kwargs.get("force") is False
     assert kwargs.get("quiet") is False
 
@@ -109,6 +110,7 @@ def test_competitions_download_parser_with_flags_succeeds(parser):
             "file.csv",
             "-p",
             "/tmp/download",
+            "--unzip",
             "--force",
             "--quiet",
         ]
@@ -117,6 +119,7 @@ def test_competitions_download_parser_with_flags_succeeds(parser):
     assert kwargs["competition"] == "my-competition"
     assert kwargs["file_name"] == "file.csv"
     assert kwargs["path"] == "/tmp/download"
+    assert kwargs["unzip"] is True
     assert kwargs["force"] is True
     assert kwargs["quiet"] is True
 

--- a/tests/unit/test_download_unzip.py
+++ b/tests/unit/test_download_unzip.py
@@ -89,6 +89,39 @@ class TestExtractAndRemoveZip(unittest.TestCase):
 
         self.assertEqual(sorted(os.listdir(self.root)), ["dest"])
 
+    def test_unwrap_to_writes_the_single_member_to_the_named_path(self):
+        archive = os.path.join(self.destination, "big.csv.zip")
+        _write_zip(archive, {"big.csv": b"payload"})
+        target = os.path.join(self.destination, "big.csv")
+
+        _extract_and_remove_zip(archive, self.destination, unwrap_to=target)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["big.csv"])
+        with open(target, "rb") as unwrapped:
+            self.assertEqual(unwrapped.read(), b"payload")
+
+    def test_unwrap_to_ignores_the_name_recorded_inside_the_archive(self):
+        # The server records the base name today, but the result must not depend on it.
+        nested = os.path.join(self.destination, "WICAgencies2014ytd")
+        os.makedirs(nested)
+        archive = os.path.join(nested, "Food_Costs.csv.zip")
+        _write_zip(archive, {"WICAgencies2014ytd/Food_Costs.csv": b"payload"})
+        target = os.path.join(nested, "Food_Costs.csv")
+
+        _extract_and_remove_zip(archive, nested, unwrap_to=target)
+
+        self.assertEqual(sorted(os.listdir(nested)), ["Food_Costs.csv"])
+        with open(target, "rb") as unwrapped:
+            self.assertEqual(unwrapped.read(), b"payload")
+
+    def test_unwrap_to_falls_back_to_a_bundle_when_there_are_several_members(self):
+        archive = os.path.join(self.destination, "big.csv.zip")
+        _write_zip(archive, {"one.csv": b"a", "two.csv": b"b"})
+
+        _extract_and_remove_zip(archive, self.destination, unwrap_to=os.path.join(self.destination, "big.csv"))
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["one.csv", "two.csv"])
+
     def test_corrupted_archive_raises_value_error(self):
         archive = os.path.join(self.destination, "bundle.zip")
         with open(archive, "wb") as broken:
@@ -212,6 +245,22 @@ class TestDatasetDownloadFileUnzip(_DownloadTestCase):
 
         self.assertTrue(os.path.isfile(self._paths("WICAgencies2014ytd", "Food_Costs.csv")))
         self.assertFalse(os.path.exists(self._paths("WICAgencies2014ytd", "Food_Costs.csv.zip")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_nested_request_does_not_repeat_the_directory(self, mock_client, mock_download_file, mock_needed):
+        # An archive that stored the full requested path must not produce
+        # WICAgencies2014ytd/WICAgencies2014ytd/Food_Costs.csv.
+        self._mock_client(mock_client, "Food_Costs.csv.zip")
+        mock_download_file.side_effect = self._writes_zip({"WICAgencies2014ytd/Food_Costs.csv": b"x"})
+
+        self.api.dataset_download_file(
+            "owner/ds", "WICAgencies2014ytd/Food_Costs.csv", path=self.destination, unzip=True
+        )
+
+        self.assertTrue(os.path.isfile(self._paths("WICAgencies2014ytd", "Food_Costs.csv")))
+        self.assertFalse(os.path.exists(self._paths("WICAgencies2014ytd", "WICAgencies2014ytd")))
 
     @patch.object(KaggleApi, "download_needed", return_value=False)
     @patch.object(KaggleApi, "download_file")

--- a/tests/unit/test_download_unzip.py
+++ b/tests/unit/test_download_unzip.py
@@ -1,0 +1,329 @@
+# coding=utf-8
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../../src")
+
+from kaggle.api.kaggle_api_extended import (
+    KaggleApi,
+    _extract_and_remove_zip,
+    _is_auto_compressed,
+)
+
+
+def _signed_url(base_name):
+    """Builds a URL shaped like the signed storage URLs the API redirects downloads to."""
+    return f"https://storage.googleapis.com/kagglesdsdata/datasets/1/2/{base_name}?GoogleAccessId=x&Signature=y"
+
+
+def _write_zip(path, members):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+
+
+class TestIsAutoCompressed(unittest.TestCase):
+    """Tests for _is_auto_compressed, which recognizes the server side zip wrapper."""
+
+    def test_wrapper_around_requested_file(self):
+        self.assertTrue(_is_auto_compressed("out/creditcard.csv.zip", "creditcard.csv"))
+
+    def test_wrapper_around_file_requested_by_nested_path(self):
+        self.assertTrue(_is_auto_compressed("out/a/b/Food_Costs.csv.zip", "a/b/Food_Costs.csv"))
+
+    def test_wrapper_around_file_requested_with_backslashes(self):
+        self.assertTrue(_is_auto_compressed("out/a/b/Food_Costs.csv.zip", "a\\b\\Food_Costs.csv"))
+
+    def test_file_that_is_itself_a_zip_is_not_a_wrapper(self):
+        # The download is not renamed, so a genuine .zip in the dataset must be left alone.
+        self.assertFalse(_is_auto_compressed("out/archive.zip", "archive.zip"))
+
+    def test_uncompressed_response_is_not_a_wrapper(self):
+        self.assertFalse(_is_auto_compressed("out/train.csv", "train.csv"))
+
+    def test_unrelated_name_is_not_a_wrapper(self):
+        self.assertFalse(_is_auto_compressed("out/other.csv.zip", "train.csv"))
+
+    def test_empty_file_name_is_not_a_wrapper(self):
+        self.assertFalse(_is_auto_compressed("out/train.csv.zip", ""))
+
+
+class TestExtractAndRemoveZip(unittest.TestCase):
+    """Tests for _extract_and_remove_zip, shared by every download that honors --unzip."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.destination = os.path.join(self.root, "dest")
+        os.makedirs(self.destination)
+
+    def test_extracts_members_and_removes_the_archive(self):
+        archive = os.path.join(self.destination, "bundle.zip")
+        _write_zip(archive, {"train.csv": b"a,b\n"})
+
+        _extract_and_remove_zip(archive, self.destination)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["train.csv"])
+        with open(os.path.join(self.destination, "train.csv"), "rb") as extracted:
+            self.assertEqual(extracted.read(), b"a,b\n")
+
+    def test_preserves_directories_inside_the_archive(self):
+        archive = os.path.join(self.destination, "bundle.zip")
+        _write_zip(archive, {"train/labels.csv": b"x"})
+
+        _extract_and_remove_zip(archive, self.destination)
+
+        self.assertTrue(os.path.isfile(os.path.join(self.destination, "train", "labels.csv")))
+
+    def test_members_cannot_escape_the_destination(self):
+        archive = os.path.join(self.destination, "bundle.zip")
+        _write_zip(archive, {"../escaped.txt": b"x", "a/../../also.txt": b"y"})
+
+        _extract_and_remove_zip(archive, self.destination)
+
+        self.assertEqual(sorted(os.listdir(self.root)), ["dest"])
+
+    def test_corrupted_archive_raises_value_error(self):
+        archive = os.path.join(self.destination, "bundle.zip")
+        with open(archive, "wb") as broken:
+            broken.write(b"not a zip")
+
+        with self.assertRaises(ValueError) as context:
+            _extract_and_remove_zip(archive, self.destination)
+
+        self.assertIn("github.com/Kaggle/kaggle-cli/issues", str(context.exception))
+        self.assertTrue(os.path.exists(archive))
+
+    def test_missing_archive_raises_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            _extract_and_remove_zip(os.path.join(self.destination, "absent.zip"), self.destination)
+
+
+class _DownloadTestCase(unittest.TestCase):
+    """Shared setup for the download methods that honor --unzip."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.destination = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.destination, True)
+
+    @staticmethod
+    def _mock_client(mock_client, base_name):
+        mock_kaggle = MagicMock()
+        mock_response = MagicMock()
+        mock_response.request.url = _signed_url(base_name)
+        mock_response.url = _signed_url(base_name)
+        mock_kaggle.datasets.dataset_api_client.download_dataset.return_value = mock_response
+        mock_kaggle.competitions.competition_api_client.download_data_file.return_value = mock_response
+        mock_kaggle.competitions.competition_api_client.download_data_files.return_value = mock_response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    @staticmethod
+    def _writes_zip(members):
+        """A download_file side effect that puts a real archive where the caller expects it."""
+
+        def write(*args, **kwargs):
+            _write_zip(args[1], members)
+
+        return write
+
+    @staticmethod
+    def _writes_plain_file(data=b"payload"):
+        def write(*args, **kwargs):
+            outfile = args[1]
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            with open(outfile, "wb") as handle:
+                handle.write(data)
+
+        return write
+
+    def _paths(self, *parts):
+        return os.path.join(self.destination, *parts)
+
+
+class TestDatasetDownloadFileUnzip(_DownloadTestCase):
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_unzip_extracts_the_wrapper_and_removes_it(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "creditcard.csv.zip")
+        mock_download_file.side_effect = self._writes_zip({"creditcard.csv": b"a,b\n1,2\n"})
+
+        self.api.dataset_download_file("owner/ds", "creditcard.csv", path=self.destination, unzip=True)
+
+        self.assertTrue(os.path.isfile(self._paths("creditcard.csv")))
+        self.assertFalse(os.path.exists(self._paths("creditcard.csv.zip")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_without_unzip_the_wrapper_is_kept(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "creditcard.csv.zip")
+        mock_download_file.side_effect = self._writes_zip({"creditcard.csv": b"a,b\n1,2\n"})
+
+        self.api.dataset_download_file("owner/ds", "creditcard.csv", path=self.destination)
+
+        self.assertTrue(os.path.isfile(self._paths("creditcard.csv.zip")))
+        self.assertFalse(os.path.exists(self._paths("creditcard.csv")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_a_file_that_is_itself_a_zip_is_not_extracted(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "archive.zip")
+        mock_download_file.side_effect = self._writes_zip({"inner.csv": b"x"})
+
+        self.api.dataset_download_file("owner/ds", "archive.zip", path=self.destination, unzip=True)
+
+        self.assertTrue(os.path.isfile(self._paths("archive.zip")))
+        self.assertFalse(os.path.exists(self._paths("inner.csv")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_uncompressed_response_with_unzip_is_left_alone(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "train.csv")
+        mock_download_file.side_effect = self._writes_plain_file(b"a,b\n")
+
+        self.api.dataset_download_file("owner/ds", "train.csv", path=self.destination, unzip=True)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["train.csv"])
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_nested_request_extracts_beside_the_requested_path(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "Food_Costs.csv.zip")
+        mock_download_file.side_effect = self._writes_zip({"Food_Costs.csv": b"x"})
+
+        self.api.dataset_download_file(
+            "owner/ds", "WICAgencies2014ytd/Food_Costs.csv", path=self.destination, unzip=True
+        )
+
+        self.assertTrue(os.path.isfile(self._paths("WICAgencies2014ytd", "Food_Costs.csv")))
+        self.assertFalse(os.path.exists(self._paths("WICAgencies2014ytd", "Food_Costs.csv.zip")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=False)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_already_downloaded_archive_is_still_extracted(self, mock_client, mock_download_file, mock_needed):
+        # Matches the cached behavior of a full dataset download, see #1086.
+        self._mock_client(mock_client, "creditcard.csv.zip")
+        _write_zip(self._paths("creditcard.csv.zip"), {"creditcard.csv": b"cached"})
+
+        self.api.dataset_download_file("owner/ds", "creditcard.csv", path=self.destination, unzip=True)
+
+        mock_download_file.assert_not_called()
+        self.assertTrue(os.path.isfile(self._paths("creditcard.csv")))
+        self.assertFalse(os.path.exists(self._paths("creditcard.csv.zip")))
+
+
+class TestDatasetDownloadCliForwarding(unittest.TestCase):
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+
+    @patch.object(KaggleApi, "dataset_download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_cli_forwards_unzip_to_the_single_file_download(self, mock_client, mock_download_file):
+        mock_kaggle = MagicMock()
+        mock_kaggle.datasets.dataset_api_client.get_dataset_metadata.return_value.error_message = None
+        mock_kaggle.datasets.dataset_api_client.get_dataset_metadata.return_value.info.licenses = []
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+
+        self.api.dataset_download_cli("owner/ds", file_name="train.csv", path="/tmp/x", unzip=True)
+
+        self.assertTrue(mock_download_file.call_args.kwargs["unzip"])
+
+
+class TestCompetitionDownloadUnzip(_DownloadTestCase):
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_unzip_extracts_the_bundle_and_removes_it(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "archive.zip")
+        mock_download_file.side_effect = self._writes_zip({"train.csv": b"a\n", "test/x.csv": b"b\n"})
+
+        self.api.competition_download_files("my-competition", path=self.destination, unzip=True)
+
+        self.assertTrue(os.path.isfile(self._paths("train.csv")))
+        self.assertTrue(os.path.isfile(self._paths("test", "x.csv")))
+        self.assertFalse(os.path.exists(self._paths("my-competition.zip")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_without_unzip_the_bundle_is_kept(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "archive.zip")
+        mock_download_file.side_effect = self._writes_zip({"train.csv": b"a\n"})
+
+        self.api.competition_download_files("my-competition", path=self.destination)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["my-competition.zip"])
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_bundle_that_is_not_a_zip_is_left_alone(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "archive.tar")
+        mock_download_file.side_effect = self._writes_plain_file(b"not a zip")
+
+        self.api.competition_download_files("my-competition", path=self.destination, unzip=True)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["my-competition.tar"])
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_single_file_wrapper_is_extracted(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "big.csv.zip")
+        mock_download_file.side_effect = self._writes_zip({"big.csv": b"x"})
+
+        self.api.competition_download_file("my-competition", "big.csv", path=self.destination, unzip=True)
+
+        self.assertTrue(os.path.isfile(self._paths("big.csv")))
+        self.assertFalse(os.path.exists(self._paths("big.csv.zip")))
+
+    @patch.object(KaggleApi, "download_needed", return_value=True)
+    @patch.object(KaggleApi, "download_file")
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_single_uncompressed_file_with_unzip_is_left_alone(self, mock_client, mock_download_file, mock_needed):
+        self._mock_client(mock_client, "train.csv")
+        mock_download_file.side_effect = self._writes_plain_file(b"a,b\n")
+
+        self.api.competition_download_file("my-competition", "train.csv", path=self.destination, unzip=True)
+
+        self.assertEqual(sorted(os.listdir(self.destination)), ["train.csv"])
+
+
+class TestCompetitionDownloadCliForwarding(unittest.TestCase):
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+
+    @patch.object(KaggleApi, "competition_download_files")
+    def test_cli_forwards_unzip_to_the_bundle_download(self, mock_download_files):
+        self.api.competition_download_cli("my-competition", path="/tmp/x", unzip=True)
+        self.assertIs(mock_download_files.call_args[0][4], True)
+
+    @patch.object(KaggleApi, "competition_download_file")
+    def test_cli_forwards_unzip_to_the_single_file_download(self, mock_download_file):
+        self.api.competition_download_cli("my-competition", file_name="train.csv", path="/tmp/x", unzip=True)
+        self.assertIs(mock_download_file.call_args[0][5], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`--unzip` did nothing when downloading a single file with `-f`, and `kaggle competitions download` had no `--unzip` at all. Both halves are what #158 asks for, and the single file case is also what is reported in #9.

## Problem

Kaggle serves large dataset files inside a zip archive named after the request, so `creditcard.csv` arrives as `creditcard.csv.zip`. That is the case `--unzip` exists for, and it was the one case the flag did not cover:

```bash
kaggle datasets download mlg-ulb/creditcardfraud -f creditcard.csv -p out --unzip
```

```text
Downloading creditcard.csv.zip to out
```

`out/creditcard.csv.zip` was 69 MB and still zipped, and the command exited 0. `dataset_download_cli` forwarded `unzip` to `dataset_download_files` but not to `dataset_download_file`:

```python
if file_name is None:
    self.dataset_download_files(dataset, path=path, unzip=unzip, force=force, quiet=quiet, licenses=licenses)
else:
    self.dataset_download_file(dataset, file_name, path=path, force=force, quiet=quiet, licenses=licenses)
```

Separately, `--unzip` was registered only on the datasets parser, so a competition bundle always had to be extracted by hand.

## Solution

`unzip` is forwarded to `dataset_download_file`, the flag is added to the competitions download parser and threaded through both competition download paths, and one `_extract_and_remove_zip()` helper now serves all four call sites, replacing the extraction block that was inlined in `dataset_download_files`.

Extraction of a single file is limited to a response named exactly `<requested>.zip`:

```python
def _is_auto_compressed(outfile: str, file_name: str) -> bool:
```

A download is never renamed, so a file that is genuinely a `.zip` inside a dataset does not match and is left alone. A competition bundle served in any format other than zip is also left as is.

`zipfile.extractall()` drops `..` segments and absolute prefixes from member names, so extraction stays inside the destination. There is a test for that.

The helper reuses the existing `ISSUE_TRACKER_URL` constant instead of the two hardcoded variants of the repository URL that were in the old block, one of which pointed at the repository root rather than the issue tracker.

## Behavior

```bash
kaggle datasets download mlg-ulb/creditcardfraud -f creditcard.csv -p out --unzip
# out/creditcard.csv, 150828752 bytes, no archive left behind

kaggle competitions download titanic -p out --unzip
# out/train.csv, out/test.csv, out/gender_submission.csv
```

Without `--unzip` nothing changes. An archive that is already on disk is extracted without being downloaded again, which matches how a full dataset download has behaved since #1086.

## Testing

- [x] `hatch -e test run pytest tests/unit/test_download_unzip.py -v` (26 passed)
- [x] `hatch -e test run pytest tests/unit` (1336 passed, 3 skipped)
- [x] `hatch run lint:all`
- [x] Verified against the live API: the single file case above extracts to 150828752 bytes with no archive left; `competitions download --unzip` on titanic writes the three csv files and no zip; a full dataset download with `--unzip` still writes 68 files and no zip through the shared helper; a cached archive is extracted without a second download; and a plain uncompressed file, a competition bundle download without the flag, and a competition single file with the flag are all unchanged
- [ ] Maintainer: please run `/gcbrun` when convenient

New tests cover the wrapper rule, a file that is itself a `.zip`, an uncompressed response, a nested request, a cached archive, the bundle case with and without the flag, a bundle that is not a zip, extraction that would escape the destination, a corrupted archive, a missing archive, and that both CLI wrappers forward the flag. The eight behavior tests fail against the previous code.

Docs updated in `docs/datasets.md`, `docs/competitions.md`, `skills/references/datasets.md`, and `skills/references/competitions.md`.

## Related

Fixes #158
Fixes #9
