### PR TITLE
feat(cli): add --no-run to kernels push to save a version without running it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Add `--no-run` to `kaggle kernels push` to save a new version without executing the notebook, the equivalent of Quick Save in the web UI
 * Keep the requested folder when downloading a single file with `kaggle datasets download -f` or `kaggle competitions download -f`, instead of writing it to the download root
 * Add `kaggle competitions host-add <comp> -u <user>` to grant host access on a competition to a Kaggle user
 * Suggest a next step on 403/404/429/5xx API errors, report unexpected errors as bugs instead of a traceback (with a new `--debug` flag), and list common examples in `kaggle --help`

--- a/docs/kernels.md
+++ b/docs/kernels.md
@@ -124,7 +124,7 @@ This command creates a template `kernel-metadata.json` file. You need to edit th
 
 ## `kaggle kernels push`
 
-Pushes new code/notebook and metadata to a kernel, then runs the kernel.
+Pushes new code/notebook and metadata to a kernel, then runs the kernel. Pass `--no-run` to save a new version without running it.
 
 **Usage:**
 
@@ -137,6 +137,7 @@ kaggle kernels push -p <FOLDER_PATH> [options]
 *   `--accelerator <ACCELERATOR_ID>`: ID name of the accelerator to use during the run. E.g. "NvidiaTeslaP100" (aka default GPU), "NvidiaTeslaT4", "TpuV6E8".
 *   `-p, --path <FOLDER_PATH>`: Path to the folder containing the kernel file (e.g., `.ipynb`, `.Rmd`, `.py`) and the `kernel-metadata.json` file (defaults to the current directory).
 *   `-t, --timeout <SECONDS>`: Maximum run time in seconds.
+*   `--no-run`: Save a new version without executing the notebook, the equivalent of Quick Save in the web UI. The version is created but no cell runs.
 
 **Example:**
 
@@ -144,6 +145,12 @@ Push the kernel from the `tests/kernel` folder (assuming it contains the kernel 
 
 ```bash
 kaggle kernels push -p tests/kernel
+```
+
+Save a new version without running it, for example after editing only a markdown cell:
+
+```bash
+kaggle kernels push -p tests/kernel --no-run
 ```
 
 **Purpose:**

--- a/skills/references/kernels.md
+++ b/skills/references/kernels.md
@@ -112,7 +112,7 @@ kaggle kernels init -p my-kernel
 
 ## `kaggle kernels push`
 
-Pushes code to a kernel and runs it.
+Pushes code to a kernel and runs it, or saves a version without running when `--no-run` is passed.
 
 **Usage:**
 
@@ -125,12 +125,14 @@ kaggle kernels push [options]
 - `-p, --path <FOLDER>`: Folder containing files and `kernel-metadata.json`.
 - `-t, --timeout <SECONDS>`: Limit run time, bounded by Kaggle's maximum.
 - `--accelerator <ACCELERATOR>`: Accelerator type for the kernel run.
+- `--no-run`: Save a new version without executing the notebook, the equivalent of Quick Save in the web UI.
 
 **Examples:**
 
 ```bash
 kaggle kernels push -p my-kernel --timeout 3600 --accelerator gpu
 kaggle kernels update -p my-kernel
+kaggle kernels push -p my-kernel --no-run
 ```
 
 **Purpose:** Upload local notebook/script code and create a new kernel version.

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -216,7 +216,7 @@ from kagglesdk.kernels.types.kernels_api_service import (
     ApiDeleteKernelRequest,
     ApiGetAcceleratorQuotaStatisticsRequest,
 )
-from kagglesdk.kernels.types.kernels_enums import KernelsListSortType, KernelsListViewType
+from kagglesdk.kernels.types.kernels_enums import KernelExecutionType, KernelsListSortType, KernelsListViewType
 from kagglesdk.models.types.model_api_service import (
     ApiListModelsRequest,
     ApiCreateModelRequest,
@@ -7035,7 +7035,7 @@ class KaggleApi:
         print("Kernel metadata template written to: " + meta_file)
 
     def kernels_push(
-        self, folder: str, timeout: Optional[str] = None, acc: Optional[str] = None
+        self, folder: str, timeout: Optional[str] = None, acc: Optional[str] = None, no_run: bool = False
     ) -> ApiSaveKernelResponse:
         """Pushes a kernel to Kaggle.
 
@@ -7050,6 +7050,8 @@ class KaggleApi:
                 with the default Kaggle image, whose PyTorch build (cu128) omits Pascal (sm_60) kernels, so the first
                 CUDA operation fails with cudaErrorNoKernelImageForDevice even though torch.cuda.is_available() returns
                 True. Use "NvidiaTeslaT4" or install a Pascal-compatible torch build.
+            no_run (bool): Save a new version without executing the notebook, the equivalent of Quick Save in
+                the web UI. The default is to save and run.
 
         Returns:
             ApiSaveKernelResponse: An ApiSaveKernelResponse object.
@@ -7169,20 +7171,23 @@ class KaggleApi:
                 request.session_timeout_seconds = int(timeout)
             # The allowed names are in an enum that is not currently included in kagglesdk.
             request.machine_shape = acc if acc else self.get_or_default(meta_data, "machine_shape", None)
+            if no_run:
+                request.kernel_execution_type = KernelExecutionType.QUICK_SAVE
             # Without the type hint, mypy thinks save_kernel() has type Any when checking warn_return_any.
             response: ApiSaveKernelResponse = kaggle.kernels.kernels_api_client.save_kernel(request)
             return response
 
-    def kernels_push_cli(self, folder, timeout, acc):
+    def kernels_push_cli(self, folder, timeout, acc, no_run=False):
         """A client wrapper for kernels_push.
 
         Args:
             folder: The path to the folder.
             timeout: The maximum run time in seconds.
             acc: The accelerator to use.
+            no_run: Save a new version without running the notebook.
         """
         folder = folder or os.getcwd()
-        result = self.kernels_push(folder, timeout, acc)
+        result = self.kernels_push(folder, timeout, acc, no_run)
 
         if result is None:
             print("Kernel push error: see previous output")
@@ -7208,14 +7213,17 @@ class KaggleApi:
                     "be added to the kernel: " + str(result.invalidKernelSources)
                 )
 
+            # A quick save never starts the notebook, so pointing at run progress would be wrong.
+            if no_run:
+                outcome, where = "saved without running", "See"
+            else:
+                outcome, where = "pushed", "Please check progress at"
+
             if result.versionNumber:
-                print(
-                    "Kernel version %s successfully pushed.  Please check "
-                    "progress at %s" % (result.versionNumber, result.url)
-                )
+                print("Kernel version %s successfully %s.  %s %s" % (result.versionNumber, outcome, where, result.url))
             else:
                 # Shouldn't happen but didn't test exhaustively
-                print("Kernel version successfully pushed.  Please check " "progress at %s" % result.url)
+                print("Kernel version successfully %s.  %s %s" % (outcome, where, result.url))
         else:
             print("Kernel push error: " + result.error)
 

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1419,6 +1419,9 @@ def parse_kernels(subparsers) -> None:
         "-t", "--timeout", type=int, dest="timeout", help=Help.param_kernel_timeout
     )
     parser_kernels_push_optional.add_argument("--accelerator", dest="acc", help=Help.param_kernel_acc)
+    parser_kernels_push_optional.add_argument(
+        "--no-run", dest="no_run", action="store_true", help=Help.param_kernel_no_run
+    )
     parser_kernels_push._action_groups.append(parser_kernels_push_optional)
     parser_kernels_push.set_defaults(func=api.kernels_push_cli)
 
@@ -3021,6 +3024,11 @@ options a specific command accepts."""
     param_kernel_pull_metadata = "Generate metadata when pulling kernel"
     param_kernel_output_file_pattern = (
         "Regex pattern to match against filenames. Only files matching the pattern will be downloaded."
+    )
+    param_kernel_no_run = (
+        "Save a new version without running the notebook, the equivalent of Quick Save in the web UI.\n"
+        "The version is created but no cell is executed. Use this when only prose, metadata or\n"
+        "sources changed."
     )
     param_kernel_acc = (
         "Specify the type of accelerator to use for the kernel run. Note: 'NvidiaTeslaP100' is not usable for GPU "

--- a/tests/unit/test_cli_kernels.py
+++ b/tests/unit/test_cli_kernels.py
@@ -136,6 +136,14 @@ def test_kernels_push_parser_default_succeeds(parser):
     assert kwargs.get("folder") is None
     assert kwargs.get("timeout") is None
     assert kwargs.get("acc") is None
+    assert kwargs.get("no_run") is False
+
+
+def test_kernels_push_parser_no_run_flag_succeeds(parser):
+    func, kwargs = parser.dispatch(["kernels", "push", "-p", "/path/to/kernel", "--no-run"])
+    assert func.__name__ == "kernels_push_cli"
+    assert kwargs["folder"] == "/path/to/kernel"
+    assert kwargs["no_run"] is True
 
 
 def test_kernels_push_parser_with_flags_succeeds(parser):

--- a/tests/unit/test_kernels_push_no_run.py
+++ b/tests/unit/test_kernels_push_no_run.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
+
+from kagglesdk.kernels.types.kernels_enums import KernelExecutionType
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class _PushTestCase(unittest.TestCase):
+    """Shared setup for pushing a minimal, valid kernel."""
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.valid_push_language_types = ["python", "r", "julia", "rmarkdown"]
+        self.api.valid_push_kernel_types = ["script", "notebook"]
+        self.api.valid_push_pinning_types = ["original", "latest"]
+        self.api.KERNEL_METADATA_FILE = "kernel-metadata.json"
+
+    @staticmethod
+    def _mock_client(mock_client):
+        mock_kaggle = MagicMock()
+        response = MagicMock()
+        response.error = None
+        response.invalidTags = []
+        response.invalidDatasetSources = []
+        response.invalidCompetitionSources = []
+        response.invalidKernelSources = []
+        response.versionNumber = 3
+        response.url = "https://www.kaggle.com/code/testuser/test-kernel"
+        mock_kaggle.kernels.kernels_api_client.save_kernel.return_value = response
+        mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+        mock_client.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_kaggle
+
+    def _kernel_folder(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir, True)
+        metadata = {
+            "id": "testuser/test-kernel",
+            "title": "Test Kernel Title",
+            "code_file": "script.py",
+            "language": "python",
+            "kernel_type": "script",
+        }
+        with open(os.path.join(tmpdir, self.api.KERNEL_METADATA_FILE), "w", encoding="utf-8") as meta:
+            json.dump(metadata, meta)
+        with open(os.path.join(tmpdir, "script.py"), "w", encoding="utf-8") as code:
+            code.write("print('hello')\n")
+        return tmpdir
+
+    @staticmethod
+    def _sent_request(mock_kaggle):
+        mock_kaggle.kernels.kernels_api_client.save_kernel.assert_called_once()
+        return mock_kaggle.kernels.kernels_api_client.save_kernel.call_args[0][0]
+
+
+class TestKernelsPushNoRun(_PushTestCase):
+    """Tests that --no-run maps to the QUICK_SAVE execution type."""
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_no_run_requests_a_quick_save(self, mock_client):
+        mock_kaggle = self._mock_client(mock_client)
+
+        self.api.kernels_push(self._kernel_folder(), no_run=True)
+
+        self.assertEqual(self._sent_request(mock_kaggle).kernel_execution_type, KernelExecutionType.QUICK_SAVE)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_default_push_leaves_the_execution_type_unspecified(self, mock_client):
+        # Not setting the field is what makes the server save and run, so the default must not change.
+        mock_kaggle = self._mock_client(mock_client)
+
+        self.api.kernels_push(self._kernel_folder())
+
+        request = self._sent_request(mock_kaggle)
+        self.assertNotEqual(request.kernel_execution_type, KernelExecutionType.QUICK_SAVE)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_accelerator_and_timeout_still_apply_with_no_run(self, mock_client):
+        mock_kaggle = self._mock_client(mock_client)
+
+        self.api.kernels_push(self._kernel_folder(), timeout=600, acc="NvidiaTeslaT4", no_run=True)
+
+        request = self._sent_request(mock_kaggle)
+        self.assertEqual(request.kernel_execution_type, KernelExecutionType.QUICK_SAVE)
+        self.assertEqual(request.machine_shape, "NvidiaTeslaT4")
+        self.assertEqual(request.session_timeout_seconds, 600)
+
+
+class TestKernelsPushCliNoRun(_PushTestCase):
+    """Tests the wrapper forwarding and the message it prints."""
+
+    @patch.object(KaggleApi, "kernels_push")
+    def test_cli_forwards_no_run(self, mock_push):
+        mock_push.return_value = MagicMock(error=None, versionNumber=3, url="u")
+
+        with redirect_stdout(io.StringIO()):
+            self.api.kernels_push_cli("folder", None, None, True)
+
+        self.assertIs(mock_push.call_args[0][3], True)
+
+    @patch.object(KaggleApi, "kernels_push")
+    def test_cli_defaults_to_running(self, mock_push):
+        mock_push.return_value = MagicMock(error=None, versionNumber=3, url="u")
+
+        with redirect_stdout(io.StringIO()):
+            self.api.kernels_push_cli("folder", None, None)
+
+        self.assertIs(mock_push.call_args[0][3], False)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_no_run_does_not_point_at_run_progress(self, mock_client):
+        self._mock_client(mock_client)
+        folder = self._kernel_folder()
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.api.kernels_push_cli(folder, None, None, True)
+
+        printed = output.getvalue()
+        self.assertIn("successfully saved without running", printed)
+        self.assertNotIn("check progress", printed)
+        self.assertIn("https://www.kaggle.com/code/testuser/test-kernel", printed)
+
+    @patch.object(KaggleApi, "build_kaggle_client")
+    def test_default_message_is_unchanged(self, mock_client):
+        self._mock_client(mock_client)
+        folder = self._kernel_folder()
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.api.kernels_push_cli(folder, None, None)
+
+        self.assertIn(
+            "Kernel version 3 successfully pushed.  Please check progress at "
+            "https://www.kaggle.com/code/testuser/test-kernel",
+            output.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`kaggle kernels push` always queues a full execution, so correcting a typo in a markdown cell means re-running the whole notebook. This adds `--no-run`, which saves a new version without executing it, the equivalent of Quick Save in the web UI.

## Problem

There is no way to save a version without running it. I hit this during a playground competition, where a one word fix in a markdown cell cost a full re-run, twice.

`kernels push` accepts only `-p/--path`, `-t/--timeout` and `--accelerator`.

## Solution

The API already supports this and the CLI was not passing it through. `ApiSaveKernelRequest` carries:

```text
kernel_execution_type (KernelExecutionType)
  Which kernel version type to use.
```

and the pinned kagglesdk has:

```python
class KernelExecutionType(enum.Enum):
  KERNEL_EXECUTION_TYPE_UNSPECIFIED = 0
  SAVE_AND_RUN_ALL = 1
  INTER_ACTIVE = 2
  QUICK_SAVE = 3
```

`kernel_execution_type` did not appear anywhere in `kaggle_api_extended.py` or `cli.py`, so every push left it unspecified and the server saved and ran.

`--no-run` sets the field to `QUICK_SAVE`. The default path does not set it at all, so nothing changes for existing users. No kagglesdk bump is needed.

The success message is adjusted for that case, because pointing at run progress when nothing is running would be misleading:

```text
kaggle kernels push -p my-kernel
Kernel version 2 successfully pushed.  Please check progress at https://www.kaggle.com/code/...

kaggle kernels push -p my-kernel --no-run
Kernel version 1 successfully saved without running.  See https://www.kaggle.com/code/...
```

## Testing

- [x] `hatch -e test run pytest tests/unit/test_kernels_push_no_run.py -v` (7 passed)
- [x] `hatch -e test run pytest tests/unit` (1318 passed, 3 skipped)
- [x] `hatch run lint:all`
- [x] Verified against the live API by pushing the same private notebook twice, with a single cell of `print("MARKER")` followed by `time.sleep(40)`:

| push | status | the notebook's own output in the log |
|------|--------|--------------------------------------|
| `--no-run` | RUNNING, then COMPLETE after 24s | absent |
| unchanged | RUNNING for 60s, then COMPLETE | present once |

The quick saved version settled in less time than its own sleep and its log holds no cell output, so the version was created without the cells being executed. The control run behaves exactly as before.

- [ ] Maintainer: please run `/gcbrun` when convenient

New tests cover that `--no-run` sets `QUICK_SAVE`, that a default push leaves the execution type unset, that `--accelerator` and `--timeout` still apply alongside it, that both CLI wrappers forward the flag, and that each of the two success messages is produced. Seven of the nine fail against the previous code; the two that do not are the regression guards on the default path.

Docs updated in `docs/kernels.md` and `skills/references/kernels.md`.

## A note on the flag name

I went with `--no-run` because it matches the request in #493 and the existing `--no-resume`, `--no-compress`, `--no-warn` style in this CLI. `--quick-save` would match the web UI and the enum more literally. Happy to rename if you prefer that.

Worth being precise about what it does: a session is still created briefly to render the version, so `kernels status` reports RUNNING for a few seconds. What does not happen is any cell executing. The help text and docs say it that way rather than promising that nothing runs at all.

## Related

Fixes #493
