### PR TITLE
Keep datasets files JSON output parseable

### DIFF
--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -5429,7 +5429,10 @@ class KaggleApi:
             else:
                 next_page_token = result.next_page_token
                 if next_page_token:
-                    print("Next Page Token = {}".format(next_page_token))
+                    print(
+                        "Next Page Token = {}".format(next_page_token),
+                        file=sys.stderr if output_format else sys.stdout,
+                    )
                 fields = ["name", "size", "creationDate"]
                 ApiDatasetFile.size = ApiDatasetFile.total_bytes  # type: ignore[attr-defined]
                 self.print_results(

--- a/tests/unit/test_dataset_files.py
+++ b/tests/unit/test_dataset_files.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock, patch
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+def test_dataset_files_json_keeps_stdout_parseable(capsys):
+    api = KaggleApi.__new__(KaggleApi)
+    response = MagicMock(error_message=None, next_page_token="next-token", files=[])
+
+    with (
+        patch.object(api, "dataset_list_files", return_value=response),
+        patch.object(api, "print_results") as print_results,
+    ):
+        api.dataset_list_files_cli("owner/dataset", output_format="json")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "Next Page Token = next-token\n"
+    print_results.assert_called_once_with([], ["name", "size", "creationDate"], csv_display=False, output_format="json")
+
+
+def test_dataset_files_table_keeps_pagination_on_stdout(capsys):
+    api = KaggleApi.__new__(KaggleApi)
+    response = MagicMock(error_message=None, next_page_token="next-token", files=[])
+
+    with (
+        patch.object(api, "dataset_list_files", return_value=response),
+        patch.object(api, "print_results"),
+    ):
+        api.dataset_list_files_cli("owner/dataset")
+
+    captured = capsys.readouterr()
+    assert captured.out == "Next Page Token = next-token\n"
+    assert captured.err == ""


### PR DESCRIPTION
Fixes #1186.

`kaggle datasets files --format json` printed the pagination token to stdout before the JSON array. The command now sends that token to stderr when an explicit output format is requested, while keeping the table/CSV stdout behavior unchanged.

Tests:
- `uv run --with pytest pytest tests/unit/test_cli_datasets.py tests/unit/test_dataset_files.py`
- `uv run --with black black --check --diff src/kaggle/api/kaggle_api_extended.py tests/unit/test_dataset_files.py`