### PR TITLE
fix(kernels): prevent output files from escaping the target path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Refuse to write a `kaggle kernels output` file whose server-supplied name resolves outside the requested `--path` directory
 * Keep the requested folder when downloading a single file with `kaggle datasets download -f` or `kaggle competitions download -f`, instead of writing it to the download root
 * Add `kaggle competitions host-add <comp> -u <user>` to grant host access on a competition to a Kaggle user
 * Suggest a next step on 403/404/429/5xx API errors, report unexpected errors as bugs instead of a traceback (with a new `--debug` flag), and list common examples in `kaggle --help`

--- a/src/kaggle/api/kaggle_api_extended.py
+++ b/src/kaggle/api/kaggle_api_extended.py
@@ -7426,11 +7426,18 @@ class KaggleApi:
             token = response.next_page_token
 
         outfiles = []
+        target_root = os.path.realpath(target_dir)
         for item in response.files or []:
             if compiled_pattern and not compiled_pattern.search(item.file_name):
                 continue
 
             outfile = os.path.join(target_dir, item.file_name)
+            # The name is relayed from the notebook's own output listing, so it is
+            # not trusted: a "../" or absolute name must not escape the target directory.
+            if not _is_within_directory(target_root, os.path.realpath(outfile)):
+                raise ValueError(
+                    f"Refusing to download '{item.file_name}': resolves outside destination '{target_dir}'"
+                )
             outfiles.append(outfile)
             download_response = requests.get(item.url, stream=True)
             # A failed fetch (e.g. an expired signed URL) still has a body, so

--- a/tests/unit/test_kernels_output_paths.py
+++ b/tests/unit/test_kernels_output_paths.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "../../src")
+
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+
+class TestKernelsOutputPaths(unittest.TestCase):
+    """Tests for where kernels_output writes server-named output files.
+
+    The file names come from the notebook's output listing, so they are not trusted:
+    a name that resolves outside the requested directory must be refused, while the
+    nested layout of legitimate output (`sub/dir/result.csv`) must be preserved.
+    """
+
+    def setUp(self):
+        self.api = KaggleApi.__new__(KaggleApi)
+        self.api.config_values = {"username": "testuser"}
+        self.api.download_needed = MagicMock(return_value=True)  # type: ignore[method-assign]
+
+    def _download(self, file_names, target_dir):
+        """Runs kernels_output against a fake listing of `file_names`; keeps the patched requests.get in self.mock_get."""
+        response = MagicMock()
+        response.files = [
+            MagicMock(file_name=name, url=f"https://example.com/{i}") for i, name in enumerate(file_names)
+        ]
+        response.next_page_token = ""
+        response.log = None
+        mock_kaggle = MagicMock()
+        mock_kaggle.kernels.kernels_api_client.list_kernel_session_output.return_value = response
+
+        with (
+            patch.object(KaggleApi, "build_kaggle_client") as mock_client,
+            patch("kaggle.api.kaggle_api_extended.requests.get") as mock_get,
+        ):
+            self.mock_get = mock_get
+            mock_get.return_value = MagicMock(content=b"payload")
+            mock_client.return_value.__enter__ = MagicMock(return_value=mock_kaggle)
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            outfiles, _ = self.api.kernels_output("owner/kernel-slug", target_dir, quiet=True)
+        return outfiles
+
+    def test_traversal_file_name_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            target_dir = os.path.join(root, "downloads")
+            with self.assertRaises(ValueError) as ctx:
+                self._download(["../outside.txt"], target_dir)
+            self.assertIn("../outside.txt", str(ctx.exception))
+            self.assertFalse(os.path.exists(os.path.join(root, "outside.txt")))
+            self.mock_get.assert_not_called()
+
+    def test_absolute_file_name_is_refused(self):
+        with tempfile.TemporaryDirectory() as root:
+            target_dir = os.path.join(root, "downloads")
+            escaped = os.path.join(root, "escaped.txt")
+            with self.assertRaises(ValueError):
+                self._download([escaped], target_dir)
+            self.assertFalse(os.path.exists(escaped))
+            self.mock_get.assert_not_called()
+
+    def test_nested_file_name_keeps_its_directory(self):
+        with tempfile.TemporaryDirectory() as root:
+            target_dir = os.path.join(root, "downloads")
+            outfiles = self._download(["result.csv", "sub/dir/result.csv"], target_dir)
+            expected = [os.path.join(target_dir, "result.csv"), os.path.join(target_dir, "sub", "dir", "result.csv")]
+            self.assertEqual([os.path.normpath(p) for p in outfiles], expected)
+            for path in expected:
+                with open(path, "rb") as f:
+                    self.assertEqual(f.read(), b"payload")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

While looking at the `kaggle kernels output` flow, I found that a server-provided file name could cause the CLI to write a file outside the directory given with `--path`.

For example, if the file name was `../outside.txt`, the CLI would join it directly with the target directory and write the file outside that directory.

The same issue also happens with absolute paths. This means the CLI was trusting the file name returned by the server without checking that the final path was still inside the requested directory.

## Fix

I added a path containment check before downloading the file.

The check uses the existing `_is_within_directory` helper and makes sure the resolved output path stays inside the requested `--path`.

If the file would escape the directory, the CLI now refuses to download it instead of writing the file.

Normal nested output paths such as `sub/dir/result.csv` still work as before.

## Tests

I added regression tests for:

* `../outside.txt`
* absolute paths
* valid nested paths

The tests also check that files with unsafe paths are rejected before they are fetched.

Ran:

`pytest tests/unit/test_kernels_output_paths.py test_kernels_logs.py test_cli_kernels.py test_download_file_paths.py`

`pytest tests/unit`

`black --check`

All unit tests pass: **1346 passed**.

I also checked the new tests against the old implementation. The traversal and absolute-path tests failed before the fix and pass with the fix.
