### PR TITLE
fix(kernels): honor -k/--kernel in kernels pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 ### Next
 
+* Honor `-k/--kernel` in `kaggle kernels pull`, which was ignored when the positional kernel argument was omitted, causing the CLI to fall back to the local `kernel-metadata.json` and pull a different kernel
 * Refuse to write a `kaggle kernels output` file whose server-supplied name resolves outside the requested `--path` directory
 * Add `--no-run` to `kaggle kernels push` to save a new version without executing the notebook, the equivalent of Quick Save in the web UI
 * Honor `--unzip` when downloading a single file with `kaggle datasets download -f`, which extracts the file from the zip archive the server wraps large files in, and add `--unzip` to `kaggle competitions download`

--- a/src/kaggle/cli.py
+++ b/src/kaggle/cli.py
@@ -1437,7 +1437,9 @@ def parse_kernels(subparsers) -> None:
     )
     parser_kernels_pull_optional = parser_kernels_pull._action_groups.pop()
     parser_kernels_pull_optional.add_argument("kernel", nargs="?", default=None, help=Help.param_kernel)
-    parser_kernels_pull_optional.add_argument("-k", "--kernel", dest="kernel", required=False, help=argparse.SUPPRESS)
+    parser_kernels_pull_optional.add_argument(
+        "-k", "--kernel", dest="kernel_opt", required=False, help=argparse.SUPPRESS
+    )
     parser_kernels_pull_optional.add_argument("-p", "--path", dest="path", required=False, help=Help.param_downfolder)
     parser_kernels_pull_optional.add_argument(
         "-w", "--wp", dest="path", action="store_const", const=".", required=False, help=Help.param_wp

--- a/tests/unit/test_cli_kernels.py
+++ b/tests/unit/test_cli_kernels.py
@@ -158,6 +158,7 @@ def test_kernels_pull_parser_default_succeeds(parser):
     func, kwargs = parser.dispatch(["kernels", "pull"])
     assert func.__name__ == "kernels_pull_cli"
     assert kwargs.get("kernel") is None
+    assert kwargs.get("kernel_opt") is None
     assert kwargs.get("path") is None
     assert kwargs.get("metadata") is False
 
@@ -171,9 +172,8 @@ def test_kernels_pull_parser_with_positional_kernel_succeeds(parser):
 def test_kernels_pull_parser_with_option_kernel_succeeds(parser):
     func, kwargs = parser.dispatch(["kernels", "pull", "-k", "owner/kernel-name"])
     assert func.__name__ == "kernels_pull_cli"
-    # Both positional and option write to dest='kernel', but because of a bug in cli.py,
-    # the option value is overwritten by the positional default (None) when positional is omitted.
     assert kwargs.get("kernel") is None
+    assert kwargs["kernel_opt"] == "owner/kernel-name"
 
 
 def test_kernels_pull_parser_with_flags_succeeds(parser):

--- a/tests/unit/test_kernels_pull.py
+++ b/tests/unit/test_kernels_pull.py
@@ -345,6 +345,12 @@ class TestKernelsPull(unittest.TestCase):
         expected_path = os.path.normpath("/tmp/default_dir/my-slug.py")
         mock_open_file.assert_called_once_with(expected_path, "w", encoding="utf-8")
 
+    @patch.object(KaggleApi, "kernels_pull")
+    def test_kernels_pull_cli_honors_kernel_opt(self, mock_pull):
+        self.api.kernels_pull_cli(None, kernel_opt="owner/my-slug")
+
+        mock_pull.assert_called_once_with("owner/my-slug", path=None, metadata=False, quiet=False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

While looking at the `kaggle kernels pull` flow, I found that the `-k/--kernel` option could be ignored when no positional kernel was provided.

For example, running:

```bash
kaggle kernels pull -k owner/kernel-name
```

could end up using the kernel ID from the local `kernel-metadata.json` instead of `owner/kernel-name`.

This happens because both the positional `kernel` argument and the `-k/--kernel` option were using the same argparse destination. The optional positional argument has a default of `None`, which overwrote the value provided through `-k`.

This could cause the CLI to pull a different kernel than the one explicitly requested. Since the pulled source is written to the local `code_file`, this could also overwrite local edits.

## Fix

I changed the `-k/--kernel` option to use the existing `kernel_opt` destination, matching the other kernel commands.

The existing `kernel = kernel or kernel_opt` logic in `kernels_pull_cli` then correctly uses the value provided through `-k`.

No changes were made to the kernel pull handler or API code.

The normal `kernel-metadata.json` fallback still works when no kernel is provided.

## Tests

I updated the existing parser test to check that the value provided through `-k` is actually preserved.

I also manually verified the behavior end-to-end with a local `kernel-metadata.json` containing a different kernel ID.

The test fails with the old implementation and passes with the fix.

Ran:

```text
tests/unit/test_cli_kernels.py tests/unit/test_kernels_pull.py
tests/unit
```

Results:

```text
40 passed
1354 passed, 1 warning
```

The warning is an existing unrelated `DeprecationWarning`.

The change is limited to the argument destination and the corresponding regression test.
